### PR TITLE
Remotes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,9 +22,16 @@ current
 - :meth:`libvcs.git.GitRepo.obtain` no longer set remotes based on a ``dict`` passed
   to :class:`~libvcs.git.GitRepo`. This was deemed to specialized / implicit.
 
+- :meth:`libvcs.git.GitRepo.set_remote()` (formerly ``remote_set``)
+
+  The new method accepts ``name`` and ``url`` (in that order). ``name`` no longer
+  has a default value (was ``origin``).
+
 - :meth:`libvcs.git.GitRepo.remote()` (formerly ``remote_get``):
 
   - ``remote`` argument renamed to ``name``. It will be removed in 0.3.4
+
+    The default value of ``'origin'`` has been removed
   - Now returns :meth:`~libvcs.git.GitRemote` (a :py:class:`collections.namedtuple` object)
 
     The tuple is similar to the old output, except there is an additional value at

--- a/CHANGES
+++ b/CHANGES
@@ -6,18 +6,35 @@ Here are the changes for libvcs.
 
 current
 -------
+
+**Breaking changes**
+
 - :class:`~libvcs.git.GitRepo` methods have been renamed, they will be deprecated
   in 0.4:
 
-  - ``GitRepo.remotes_get`` renamed to :meth:`libvcs.git.GitRepo.remotes`
-  - ``GitRepo.remote_get`` renamed to :meth:`libvcs.git.GitRepo.remote`
-  - ``GitRepo.remote_set`` renamed to :meth:`libvcs.git.~GitRepo.set_remote`
+  - ``GitRepo.remotes_get`` renamed to :meth:`libvcs.git.GitRepo.remotes()`
+  - ``GitRepo.remote_get`` renamed to :meth:`libvcs.git.GitRepo.remote()`
+  - ``GitRepo.remote_set`` renamed to :meth:`libvcs.git.GitRepo.set_remote()`
 
-- :class:`~libvcs.git.GitRepo` the ``remotes`` argumetn is deprecated and no longer
+- :class:`~libvcs.git.GitRepo` the ``remotes`` argument is deprecated and no longer
   used. Use :meth:`libvcs.git.GitRepo.set_remote` after repo is instantiated.
 
 - :meth:`libvcs.git.GitRepo.obtain` no longer set remotes based on a ``dict`` passed
   to :class:`~libvcs.git.GitRepo`. This was deemed to specialized / implicit.
+
+- :meth:`libvcs.git.GitRepo.remote()` (formerly ``remote_get``):
+
+  - ``remote`` argument renamed to ``name``. It will be removed in 0.3.4
+  - Now returns :meth:`~libvcs.git.GitRemote` (a :py:class:`collections.namedtuple` object)
+
+    The tuple is similar to the old output, except there is an additional value at
+    the beginning, the name of the remote, e.g. ``('origin', '<fetch_url>', '<push_url>')``
+
+- :meth:`libvcs.git.GitRepo.remotes()` (formerly ``remotes_get``) are now methods
+  instead of properties.
+
+  Passing ``flat=True`` to return a ``dict`` of ``tuple`` instead of ``dict``
+
 
 0.3.3 <2020-07-29>
 ------------------

--- a/CHANGES
+++ b/CHANGES
@@ -4,13 +4,16 @@ Changelog
 
 Here are the changes for libvcs.
 
-current
--------
+0.4-current
+-----------
 
 **Breaking changes**
 
+Internal functionality relating to remotes have been reorganized to avoid
+implicit behavior.
+
 - :class:`~libvcs.git.GitRepo` methods have been renamed, they will be deprecated
-  in 0.4:
+  in 0.5:
 
   - ``GitRepo.remotes_get`` renamed to :meth:`libvcs.git.GitRepo.remotes()`
   - ``GitRepo.remote_get`` renamed to :meth:`libvcs.git.GitRepo.remote()`
@@ -29,7 +32,7 @@ current
 
 - :meth:`libvcs.git.GitRepo.remote()` (formerly ``remote_get``):
 
-  - ``remote`` argument renamed to ``name``. It will be removed in 0.3.4
+  - ``remote`` argument renamed to ``name``. It will be removed in 0.5.0
 
     The default value of ``'origin'`` has been removed
   - Now returns :meth:`~libvcs.git.GitRemote` (a :py:class:`collections.namedtuple` object)

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,21 @@ Changelog
 
 Here are the changes for libvcs.
 
+current
+-------
+- :class:`~libvcs.git.GitRepo` methods have been renamed, they will be deprecated
+  in 0.4:
+
+  - ``GitRepo.remotes_get`` renamed to :meth:`libvcs.git.GitRepo.remotes`
+  - ``GitRepo.remote_get`` renamed to :meth:`libvcs.git.GitRepo.remote`
+  - ``GitRepo.remote_set`` renamed to :meth:`libvcs.git.~GitRepo.set_remote`
+
+- :class:`~libvcs.git.GitRepo` the ``remotes`` argumetn is deprecated and no longer
+  used. Use :meth:`libvcs.git.GitRepo.set_remote` after repo is instantiated.
+
+- :meth:`libvcs.git.GitRepo.obtain` no longer set remotes based on a ``dict`` passed
+  to :class:`~libvcs.git.GitRepo`. This was deemed to specialized / implicit.
+
 0.3.3 <2020-07-29>
 ------------------
 - Remove f-string from test

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -21,6 +21,11 @@ Tools like :func:`libvcs.shortcuts.create_repo` and
 :func:`libvcs.shortcuts.create_repo_from_pip_url` are just wrappers
 around instantiated these classes.
 
+See examples below of git, mercurial, and subversion.
+
+Git
+---
+
 .. autoclass:: libvcs.git.GitRepo
    :members:
    :show-inheritance:
@@ -29,9 +34,19 @@ around instantiated these classes.
    :members:
    :show-inheritance:
 
+Mercurial
+---------
+
+aka ``hg(1)``
+
 .. autoclass:: libvcs.hg.MercurialRepo
    :members:
    :show-inheritance:
+
+Subversion
+----------
+
+aka ``svn(1)``
 
 .. autoclass:: libvcs.svn.SubversionRepo
    :members:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -18,7 +18,7 @@ Instantiating a repo by hand
 ----------------------------
 
 Tools like :func:`libvcs.shortcuts.create_repo` and
-`:func:`libvcs.shortcuts.create_repo_from_pip_url` are just wrappers
+:func:`libvcs.shortcuts.create_repo_from_pip_url` are just wrappers
 around instantiated these classes.
 
 .. autoclass:: libvcs.git.GitRepo

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -25,6 +25,10 @@ around instantiated these classes.
    :members:
    :show-inheritance:
 
+.. autoclass:: libvcs.git.GitRemote
+   :members:
+   :show-inheritance:
+
 .. autoclass:: libvcs.hg.MercurialRepo
    :members:
    :show-inheritance:

--- a/libvcs/git.py
+++ b/libvcs/git.py
@@ -120,7 +120,13 @@ class GitRepo(BaseRepo):
         return url, rev
 
     def obtain(self):
-        """Retrieve the repository, clone if doesn't exist."""
+        """Retrieve the repository, clone if doesn't exist.
+
+        .. versionchanged:: 0.3.4
+
+           No longer sets remotes. This is now done manually through 
+           :meth:`~.set_remote`.
+        """
         self.check_destination()
 
         url = self.url
@@ -134,13 +140,6 @@ class GitRepo(BaseRepo):
 
         self.info('Cloning.')
         self.run(cmd, log_in_real_time=True)
-
-        if self.remotes:
-            for name, remote in self.remotes.items():
-                self.error('Adding remote %s <%s>' % (name, remote['fetch_url']))
-                self.set_remote(
-                    name=remote['name'], url=remote['fetch_url'], overwrite=True
-                )
 
         self.info('Initializing submodules.')
         self.run(['submodule', 'init'], log_in_real_time=True)

--- a/libvcs/git.py
+++ b/libvcs/git.py
@@ -43,7 +43,7 @@ class GitRepo(BaseRepo):
     bin_name = 'git'
     schemes = ('git', 'git+http', 'git+https', 'git+ssh', 'git+git', 'git+file')
 
-    def __init__(self, url, remotes=None, **kwargs):
+    def __init__(self, url, **kwargs):
         """A git repository.
 
         :param url: URL of repo
@@ -80,11 +80,12 @@ class GitRepo(BaseRepo):
         if 'tls_verify' not in kwargs:
             self.tls_verify = False
 
-        warnings.warn(
-            "'remotes' is deprecated and will be removed in 0.4.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
+        if kwargs.get('remotes') is not None:
+            warnings.warn(
+                "'remotes' is deprecated and will be removed in 0.4.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         BaseRepo.__init__(self, url, **kwargs)
 
     def get_revision(self):

--- a/libvcs/git.py
+++ b/libvcs/git.py
@@ -35,7 +35,7 @@ GitRemote = collections.namedtuple('GitRemote', ['name', 'fetch_url', 'push_url'
 
 Supports :meth:`collections.namedtuple._asdict()`
 
-.. versionadded:: 0.3.4
+.. versionadded:: 0.4.0
 """
 
 
@@ -63,12 +63,12 @@ class GitRepo(BaseRepo):
             False)
         :type tls_verify: bool
 
-        .. versionchanged:: 0.3.4
+        .. versionchanged:: 0.4.0
 
            The ``remotes`` argument is ignored. Use :meth:`~.set_remote` to set remotes
            before running :meth:`~.obtain`.
 
-           The ``remotes`` argument is deprecated and will be removed in 0.4
+           The ``remotes`` argument is deprecated and will be removed in 0.5
            
         """
         if 'git_remote_name' not in kwargs:
@@ -82,7 +82,7 @@ class GitRepo(BaseRepo):
 
         if kwargs.get('remotes') is not None:
             warnings.warn(
-                "'remotes' is deprecated and will be removed in 0.4.",
+                "'remotes' is deprecated and will be removed in 0.5.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -123,7 +123,7 @@ class GitRepo(BaseRepo):
     def obtain(self):
         """Retrieve the repository, clone if doesn't exist.
 
-        .. versionchanged:: 0.3.4
+        .. versionchanged:: 0.4.0
 
            No longer sets remotes. This is now done manually through 
            :meth:`~.set_remote`.
@@ -300,15 +300,15 @@ class GitRepo(BaseRepo):
         :param flat: Return a dict of ``tuple`` instead of ``dict``. Default False.
         :type flat: bool
 
-        .. versionchanged:: 0.3.4
+        .. versionchanged:: 0.4.0
 
            Has been changed from property to method
 
-        .. versionchanged:: 0.3.4
+        .. versionchanged:: 0.4.0
 
            The ``flat`` argument has been added to return remotes in ``tuple`` form
 
-        .. versionchanged:: 0.3.4
+        .. versionchanged:: 0.4.0
 
            This used to return a dict of tuples, it now returns a dict of dictionaries
            with ``name``, ``fetch_url``, and ``push_url``.
@@ -329,13 +329,13 @@ class GitRepo(BaseRepo):
     @property
     def remotes_get(self):
         """
-        .. versionchanged:: 0.3.4
+        .. versionchanged:: 0.4.0
 
-           The ``remotes_get`` property is deprecated and will be removed in 0.4.0. It
+           The ``remotes_get`` property is deprecated and will be removed in 0.5. It
            has been renamed ``remotes()`` and changed from property to a method.
         """
         warnings.warn(
-            "'remotes_get' is deprecated and will be removed in 0.4. "
+            "'remotes_get' is deprecated and will be removed in 0.5. "
             "Use 'remotes()' method instead.",
             DeprecationWarning,
             stacklevel=2,
@@ -351,15 +351,15 @@ class GitRepo(BaseRepo):
         :returns: remote name and url in tuple form
         :rtype: :class:`libvcs.git.GitRemote`
 
-        .. versionchanged:: 0.3.4
+        .. versionchanged:: 0.4.0
 
            The ``remote`` argument was renamed to ``name`` and will be deprecated
-           in 0.4.
+           in 0.5.
         """
 
         if kwargs.get('remote') is not None:
             warnings.warn(
-                "'remote' is deprecated and will be removed in 0.4. "
+                "'remote' is deprecated and will be removed in 0.5. "
                 "Use 'name' instead.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -382,13 +382,13 @@ class GitRepo(BaseRepo):
 
     def remote_get(self, name='origin', **kwargs):
         """
-        .. versionchanged:: 0.3.4
+        .. versionchanged:: 0.4.0
 
-           The ``remote_get`` method is deprecated and will be removed in 0.4.0. It has
+           The ``remote_get`` method is deprecated and will be removed in 0.5.0. It has
            been renamed ``remote`` 
         """
         warnings.warn(
-            "'remote_get' is deprecated and will be removed in 0.4. "
+            "'remote_get' is deprecated and will be removed in 0.5. "
             "Use 'remote' instead.",
             DeprecationWarning,
             stacklevel=2,
@@ -404,7 +404,7 @@ class GitRepo(BaseRepo):
         :param url: defines the remote URL
         :type url: str
 
-        .. versionadded:: 0.3.4
+        .. versionadded:: 0.4.0
         """
 
         url = self.chomp_protocol(url)
@@ -417,13 +417,13 @@ class GitRepo(BaseRepo):
 
     def remote_set(self, url, name='origin', overwrite=False, **kwargs):
         """
-        .. versionchanged:: 0.3.4
+        .. versionchanged:: 0.4.0
 
-           The ``remote_set`` method is deprecated and will be removed in 0.4.0. It has
+           The ``remote_set`` method is deprecated and will be removed in 0.5.0. It has
            been renamed ``set_remote``.
         """
         warnings.warn(
-            "'remote_set' is deprecated and will be removed in 0.4. "
+            "'remote_set' is deprecated and will be removed in 0.5. "
             "Use 'set_remote' instead.",
             DeprecationWarning,
             stacklevel=2,

--- a/libvcs/git.py
+++ b/libvcs/git.py
@@ -311,7 +311,7 @@ class GitRepo(BaseRepo):
         .. versionchanged:: 0.3.4
 
            This used to return a dict of tuples, it now returns a dict of dictionaries
-           with ``name``, ``push_url``, and ``fetch_url``.
+           with ``name``, ``fetch_url``, and ``push_url``.
 
         :rtype: dict
         """

--- a/libvcs/git.py
+++ b/libvcs/git.py
@@ -294,9 +294,24 @@ class GitRepo(BaseRepo):
         cmd.extend(self.git_submodules)
         self.run(cmd, log_in_real_time=True)
 
-    @property
-    def remotes(self):
+    def remotes(self, flat=False):
         """Return remotes like git remote -v.
+
+        :param flat: Return a dict of ``tuple`` instead of ``dict``. Default False.
+        :type flat: bool
+
+        .. versionchanged:: 0.3.4
+
+           Has been changed from property to method
+
+        .. versionchanged:: 0.3.4
+
+           The ``flat`` argument has been added to return remotes in ``tuple`` form
+
+        .. versionchanged:: 0.3.4
+
+           This used to return a dict of tuples, it now returns a dict of dictionaries
+           with ``name``, ``push_url``, and ``fetch_url``.
 
         :rtype: dict
         """
@@ -306,7 +321,9 @@ class GitRepo(BaseRepo):
         ret = filter(None, cmd.split('\n'))
 
         for remote_name in ret:
-            remotes[remote_name] = self.remote(remote_name)._asdict()
+            remotes[remote_name] = (
+                self.remote(remote_name) if flat else self.remote(remote_name)._asdict()
+            )
         return remotes
 
     @property
@@ -315,16 +332,16 @@ class GitRepo(BaseRepo):
         .. versionchanged:: 0.3.4
 
            The ``remotes_get`` property is deprecated and will be removed in 0.4.0. It
-           has been renamed ``remotes`` 
+           has been renamed ``remotes()`` and changed from property to a method.
         """
         warnings.warn(
             "'remotes_get' is deprecated and will be removed in 0.4. "
-            "Use 'remotes' instead.",
+            "Use 'remotes()' method instead.",
             DeprecationWarning,
             stacklevel=2,
         )
 
-        return self.remotes
+        return self.remotes()
 
     def remote(self, name='origin', **kwargs):
         """Get the fetch and push URL for a specified remote name.

--- a/libvcs/git.py
+++ b/libvcs/git.py
@@ -343,7 +343,7 @@ class GitRepo(BaseRepo):
 
         return self.remotes()
 
-    def remote(self, name='origin', **kwargs):
+    def remote(self, name, **kwargs):
         """Get the fetch and push URL for a specified remote name.
 
         :param name: the remote name used to define the fetch and push URL
@@ -396,13 +396,15 @@ class GitRepo(BaseRepo):
 
         return self.remote(name=name, **kwargs)
 
-    def set_remote(self, url, name='origin', overwrite=False):
+    def set_remote(self, name, url, overwrite=False):
         """Set remote with name and URL like git remote add.
 
-        :param url: defines the remote URL
-        :type url: str
         :param name: defines the remote name.
         :type name: str
+        :param url: defines the remote URL
+        :type url: str
+
+        .. versionadded:: 0.3.4
         """
 
         url = self.chomp_protocol(url)

--- a/libvcs/git.py
+++ b/libvcs/git.py
@@ -74,11 +74,6 @@ class GitRepo(BaseRepo):
             self.tls_verify = False
         BaseRepo.__init__(self, url, **kwargs)
 
-    @property
-    def remotes(self):
-        remotes = self.remotes_get
-        return remotes
-
     def get_revision(self):
         """Return current revision. Initial repositories return 'initial'."""
         try:
@@ -300,6 +295,8 @@ class GitRepo(BaseRepo):
         for remote_name in ret:
             remotes[remote_name] = self.remote_get(remote_name)._asdict()
         return remotes
+
+    remotes = remotes_get
 
     def remote_get(self, name='origin'):
         """Get the fetch and push URL for a specified remote name.

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -112,9 +112,9 @@ def test_remotes(parentdir, git_remote):
         repo_dir=os.path.join(str(parentdir), repo_name),
     )
     git_repo.obtain()
-    git_repo.remote_set(name=remote_name, url=remote_url)
+    git_repo.set_remote(name=remote_name, url=remote_url)
 
-    assert (remote_name, remote_url, remote_url) == git_repo.remote_get(remote_name)
+    assert (remote_name, remote_url, remote_url) == git_repo.remote(remote_name)
 
 
 def test_git_get_url_and_rev_from_pip_url():
@@ -148,11 +148,11 @@ def test_remotes_preserves_git_ssh(parentdir, git_remote):
 
     git_repo = create_repo_from_pip_url(pip_url=remote_url, repo_dir=repo_dir)
     git_repo.obtain()
-    git_repo.remote_set(name=remote_name, url=remote_url)
+    git_repo.set_remote(name=remote_name, url=remote_url)
 
     assert (
         GitRemote(remote_name, remote_url, remote_url)._asdict()
-        in git_repo.remotes_get.values()
+        in git_repo.remotes.values()
     )
 
 
@@ -167,35 +167,33 @@ def test_private_ssh_format(pip_url_kwargs):
 
 
 def test_ls_remotes(git_repo):
-    remotes = git_repo.remotes_get
+    remotes = git_repo.remotes
 
     assert 'origin' in remotes
 
 
 def test_get_remotes(git_repo):
-    assert 'origin' in git_repo.remotes_get
+    assert 'origin' in git_repo.remotes
 
 
 @pytest.mark.parametrize('repo_name,new_repo_url', [['myrepo', 'file:///apples'],])
 def test_set_remote(git_repo, repo_name, new_repo_url):
-    mynewremote = git_repo.remote_set(name=repo_name, url='file:///')
+    mynewremote = git_repo.set_remote(name=repo_name, url='file:///')
 
-    assert 'file:///' in mynewremote, 'remote_set returns remote'
+    assert 'file:///' in mynewremote, 'set_remote returns remote'
 
-    assert 'file:///' in git_repo.remote_get(
-        name=repo_name
-    ), 'remote_get returns remote'
+    assert 'file:///' in git_repo.remote(name=repo_name), 'remote returns remote'
 
-    assert 'myrepo' in git_repo.remotes_get, '.remotes_get() returns new remote'
+    assert 'myrepo' in git_repo.remotes, '.remotes() returns new remote'
 
     with pytest.raises(
         exc.CommandError,
         match='.*remote {repo_name} already exists.*'.format(repo_name=repo_name),
     ):
-        mynewremote = git_repo.remote_set(name='myrepo', url=new_repo_url)
+        mynewremote = git_repo.set_remote(name='myrepo', url=new_repo_url)
 
-    mynewremote = git_repo.remote_set(name='myrepo', url=new_repo_url, overwrite=True)
+    mynewremote = git_repo.set_remote(name='myrepo', url=new_repo_url, overwrite=True)
 
-    assert new_repo_url in git_repo.remote_get(
+    assert new_repo_url in git_repo.remote(
         name='myrepo'
     ), 'Running remove_set should overwrite previous remote'

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -146,7 +146,10 @@ def test_remotes_preserves_git_ssh(parentdir, git_remote):
     remote_name = 'myremote'
     remote_url = 'git+ssh://git@github.com/tony/AlgoXY.git'
 
-    git_repo = create_repo_from_pip_url(pip_url=remote_url, repo_dir=repo_dir)
+    git_repo = create_repo_from_pip_url(
+        pip_url='git+file://{git_remote}'.format(git_remote=git_remote),
+        repo_dir=repo_dir,
+    )
     git_repo.obtain()
     git_repo.set_remote(name=remote_name, url=remote_url)
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -155,7 +155,7 @@ def test_remotes_preserves_git_ssh(parentdir, git_remote):
 
     assert (
         GitRemote(remote_name, remote_url, remote_url)._asdict()
-        in git_repo.remotes.values()
+        in git_repo.remotes().values()
     )
 
 
@@ -170,13 +170,14 @@ def test_private_ssh_format(pip_url_kwargs):
 
 
 def test_ls_remotes(git_repo):
-    remotes = git_repo.remotes
+    remotes = git_repo.remotes()
 
     assert 'origin' in remotes
+    assert 'origin' in git_repo.remotes(flat=True)
 
 
 def test_get_remotes(git_repo):
-    assert 'origin' in git_repo.remotes
+    assert 'origin' in git_repo.remotes()
 
 
 @pytest.mark.parametrize('repo_name,new_repo_url', [['myrepo', 'file:///apples'],])
@@ -187,7 +188,7 @@ def test_set_remote(git_repo, repo_name, new_repo_url):
 
     assert 'file:///' in git_repo.remote(name=repo_name), 'remote returns remote'
 
-    assert 'myrepo' in git_repo.remotes, '.remotes() returns new remote'
+    assert 'myrepo' in git_repo.remotes(), '.remotes() returns new remote'
 
     with pytest.raises(
         exc.CommandError,


### PR DESCRIPTION
`GitRepo` used to accept a config of `remotes`

This was intended for the object to set and fetch remotes automatically when `.obtain` is used

Instead, keep GitRepo plain as the `git clone` command (even less so, all it should really need is to operate in)

<details><summary>For later</summary>
<p>
For later:

`GitRepo(path='moo')` 

You can now run command within the context of this dorectory

`repo.run('status')`

There's also helpers:

`repo.remotes` : Returns `GitRemote` namedTuple.  Abstraction of `git remotes show`

`GitRepo.open` - open a repo on your file system, shortcut for `GitRepo(path='')`
`GitRepo.from_pip_url` - allows entering a pip url
`GitRepo.from_url` (default) - 
</p>
</details>