### PR TITLE
ci(tests): Use poetry cache action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Filter changed file paths to outputs
         uses: dorny/paths-filter@v2.7.0
         id: changes
@@ -33,16 +33,6 @@ jobs:
         if: steps.changes.outputs.docs == 'true' || steps.changes.outputs.root_docs == 'true' || steps.changes.outputs.python_files == 'true'
         run: echo "PUBLISH=$(echo true)" >> $GITHUB_ENV
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
       - name: Install poetry
         run: |
           curl -O -sSL https://install.python-poetry.org/install-poetry.py
@@ -50,32 +40,14 @@ jobs:
           echo "PATH=${HOME}/.poetry/bin:${PATH}" >> $GITHUB_ENV
           rm install-poetry.py
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+
       - name: Add ~/.local/bin to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Get poetry cache paths from config
-        run: |
-          echo "poetry_virtualenvs_path=$(poetry config --list | sed -n 's/.*virtualenvs.path = .* # //p' | sed -e 's/^\"//' -e 's/\"$//')" >> $GITHUB_ENV
-          echo "poetry_virtualenvs_path=$(poetry config --list | sed -n 's/.*virtualenvs.path = .* # //p' | sed -e 's/^\"//' -e 's/\"$//')" >> $GITHUB_ENV
-
-      - name: Configure poetry
-        shell: bash
-        run: poetry config virtualenvs.in-project true
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: |
-            .venv
-            {{ env.poetry_cache_dir }}
-            {{ env.poetry_virtualenvs_path }}
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        shell: bash
-        run: poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
 
       - name: Install dependencies [w/ docs]
         run: poetry install --extras "docs lint"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,17 +9,7 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Get full Python version
-        id: full-python-version
-        shell: bash
-        run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
-
+      - uses: actions/checkout@v3
       - name: Install poetry
         run: |
           curl -O -sSL https://install.python-poetry.org/install-poetry.py
@@ -27,32 +17,14 @@ jobs:
           echo "PATH=${HOME}/.poetry/bin:${PATH}" >> $GITHUB_ENV
           rm install-poetry.py
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+
       - name: Add ~/.local/bin to PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Get poetry cache paths from config
-        run: |
-          echo "poetry_virtualenvs_path=$(poetry config --list | sed -n 's/.*virtualenvs.path = .* # //p' | sed -e 's/^\"//' -e 's/\"$//')" >> $GITHUB_ENV
-          echo "poetry_virtualenvs_path=$(poetry config --list | sed -n 's/.*virtualenvs.path = .* # //p' | sed -e 's/^\"//' -e 's/\"$//')" >> $GITHUB_ENV
-
-      - name: Configure poetry
-        shell: bash
-        run: poetry config virtualenvs.in-project true
-
-      - name: Set up cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: |
-            .venv
-            ${{ env.poetry_cache_dir }}
-            ${{ env.poetry_virtualenvs_path }}
-          key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Ensure cache is healthy
-        if: steps.cache.outputs.cache-hit == 'true'
-        shell: bash
-        run: poetry run pip --version >/dev/null 2>&1 || rm -rf .venv
 
       - name: Install dependencies
         run: poetry install -E "docs test coverage lint format"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Test with pytest
         run: poetry run py.test --cov=./ --cov-report=xml
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGES
+++ b/CHANGES
@@ -51,6 +51,8 @@ $ pip install --user --upgrade --pre libvcs
 
 - Add codeql analysis (:issue:`303`)
 - git test suite: Lots of parametrization (:issue:`309`)
+- CI: Use poetry caching from
+  [@actions/setup v3.1](https://github.com/actions/setup-python/releases/tag/v3.1.0), (:issue:`316`)
 - New constants for `str` -> class mappings
 
   - {data}`libvcs.shortcuts.DEFAULT_VCS_CLASS_MAP`


### PR DESCRIPTION
As of yesterday, `@actions/setup-python@v3` supports this via v3.1.0: [Release](https://github.com/actions/setup-python/releases/tag/v3.1.0), [Tag](https://github.com/actions/setup-python/tree/v3.1.0), https://github.com/actions/setup-python/pull/281

```yaml
steps:
- uses: actions/checkout@v3
- name: Install poetry
  run: pipx install poetry
- uses: actions/setup-python@v3
  with:
    python-version: '3.9'
    cache: 'poetry'
- run: poetry install
- run: poetry run pytest
```

 See also: https://github.com/python-poetry/poetry/discussions/4205