### PR TITLE
refactor!: Rename `repo_dir` to `dir`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,14 @@ $ pip install --user --upgrade --pre libvcs
 
 - `GitRepo`, `SVNRepo`, `MercurialRepo`, `BaseRepo` have been moved to
   `libvcs.states.{module}.{Module}Repo`
+- `repo_dir` param is renamed to `dir`:
+
+  Before: `GitRepo(url='...', repo_dir='...')`
+
+  After: `GitRepo(url='...', dir='...')`
+
+  {issue}`#324`
+
 - Logging functions moved to {attr}`libvcs.states.base.BaseRepo.log` ({issue}`#322`)
 - Rename `RepoLoggingAdapter` to `CmdLoggingAdapter`
 - `CmdLoggingAdapter`: Rename `repo_name` param to `keyword`

--- a/README.md
+++ b/README.md
@@ -34,14 +34,17 @@ to inspect / checkout / update:
 >>> from libvcs.shortcuts import create_repo_from_pip_url, create_repo
 
 # repo is an object representation of a vcs repository.
->>> r = create_repo(url='https://www.github.com/vcs-python/libtmux',
-...                 vcs='git',
-...                 repo_dir='/tmp/libtmux')
+>>> r = create_repo(
+...     url='https://www.github.com/vcs-python/libtmux',
+...     vcs='git',
+...     dir='/tmp/libtmux'
+... )
 
 # or via pip-style URL
 >>> r = create_repo_from_pip_url(
-...         pip_url='git+https://www.github.com/vcs-python/libtmux',
-...         repo_dir='/tmp/libtmux')
+...     pip_url='git+https://www.github.com/vcs-python/libtmux',
+...     dir='/tmp/libtmux'
+... )
 ```
 
 Update / clone repo:

--- a/libvcs/conftest.py
+++ b/libvcs/conftest.py
@@ -301,7 +301,7 @@ def git_repo(projects_path: pathlib.Path, git_remote_repo: pathlib.Path):
     """Pre-made git clone of remote repo checked out to user's projects dir."""
     git_repo = GitRepo(
         url=f"file://{git_remote_repo}",
-        repo_dir=str(projects_path / "git_repo"),
+        dir=str(projects_path / "git_repo"),
         remotes={
             "origin": GitRemoteDict(
                 **{

--- a/libvcs/shortcuts.py
+++ b/libvcs/shortcuts.py
@@ -16,7 +16,7 @@ def create_repo(
     >>> r = create_repo(
     ...     url=f'file://{create_git_remote_repo()}',
     ...     vcs='git',
-    ...     repo_dir=tmp_path
+    ...     dir=tmp_path
     ... )
 
     >>> isinstance(r, GitRepo)
@@ -43,7 +43,7 @@ def create_repo_from_pip_url(
     >>> from libvcs.shortcuts import create_repo_from_pip_url
     >>> r = create_repo_from_pip_url(
     ...     pip_url=f'git+{create_git_remote_repo()}',
-    ...     repo_dir=tmp_path
+    ...     dir=tmp_path
     ... )
     >>> isinstance(r, GitRepo)
     True

--- a/libvcs/states/base.py
+++ b/libvcs/states/base.py
@@ -40,7 +40,7 @@ class BaseRepo:
     #: vcs app name, e.g. 'git'
     bin_name = ""
 
-    def __init__(self, url, repo_dir, progress_callback=None, *args, **kwargs):
+    def __init__(self, url, dir, progress_callback=None, *args, **kwargs):
         r"""
         Parameters
         ----------
@@ -63,7 +63,7 @@ class BaseRepo:
             ...         )
             >>> r = Repo(
             ...     url=f'file://{create_git_remote_repo()}',
-            ...     repo_dir=str(tmp_path),
+            ...     dir=str(tmp_path),
             ...     progress_callback=progress_cb
             ... )
             >>> r.obtain()  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS +REPORT_CDIFF
@@ -81,13 +81,13 @@ class BaseRepo:
         self.progress_callback = progress_callback
 
         #: Parent directory
-        self.parent_dir = os.path.dirname(repo_dir)
+        self.parent_dir = os.path.dirname(dir)
 
         #: Checkout path
-        self.path = repo_dir
+        self.path = dir
 
         #: Base name of checkout
-        self.repo_name = os.path.basename(os.path.normpath(repo_dir))
+        self.repo_name = os.path.basename(os.path.normpath(dir))
 
         if "rev" in kwargs:
             self.rev = kwargs["rev"]

--- a/libvcs/states/git.py
+++ b/libvcs/states/git.py
@@ -140,7 +140,7 @@ class GitRepo(BaseRepo):
     schemes = ("git", "git+http", "git+https", "git+ssh", "git+git", "git+file")
 
     def __init__(
-        self, url: str, repo_dir: str, remotes: GitRemotesArgs = None, *args, **kwargs
+        self, url: str, dir: str, remotes: GitRemotesArgs = None, *args, **kwargs
     ):
         """A git repository.
 
@@ -164,7 +164,7 @@ class GitRepo(BaseRepo):
 
             repo = GitRepo(
                url="https://github.com/vcs-python/libvcs",
-               repo_dir=checkout,
+               dir=checkout,
                remotes={
                    'gitlab': 'https://gitlab.com/vcs-python/libvcs'
                }
@@ -179,7 +179,7 @@ class GitRepo(BaseRepo):
 
             repo = GitRepo(
                url="https://github.com/vcs-python/libvcs",
-               repo_dir=checkout,
+               dir=checkout,
                remotes={
                    'gitlab': {
                        'fetch_url': 'https://gitlab.com/vcs-python/libvcs',
@@ -221,7 +221,7 @@ class GitRepo(BaseRepo):
                 fetch_url=url,
                 push_url=url,
             )
-        BaseRepo.__init__(self, url, repo_dir, *args, **kwargs)
+        BaseRepo.__init__(self, url, dir, *args, **kwargs)
         self.url = self.chomp_protocol(
             (
                 self._remotes.get("origin")
@@ -592,7 +592,7 @@ class GitRepo(BaseRepo):
         --------
         >>> git_repo = GitRepo(
         ...     url=f'file://{create_git_remote_repo()}',
-        ...     repo_dir=tmp_path
+        ...     dir=tmp_path
         ... )
         >>> git_repo.obtain()
         >>> git_repo.status()

--- a/libvcs/states/hg.py
+++ b/libvcs/states/hg.py
@@ -20,8 +20,8 @@ class MercurialRepo(BaseRepo):
     bin_name = "hg"
     schemes = ("hg", "hg+http", "hg+https", "hg+file")
 
-    def __init__(self, url, repo_dir, *args, **kwargs):
-        BaseRepo.__init__(self, url, repo_dir, *args, **kwargs)
+    def __init__(self, url, dir, *args, **kwargs):
+        BaseRepo.__init__(self, url, dir, *args, **kwargs)
 
     def obtain(self, *args, **kwargs):
         self.ensure_dir()

--- a/libvcs/states/svn.py
+++ b/libvcs/states/svn.py
@@ -34,7 +34,7 @@ class SubversionRepo(BaseRepo):
     bin_name = "svn"
     schemes = ("svn", "svn+ssh", "svn+http", "svn+https", "svn+svn")
 
-    def __init__(self, url, repo_dir, *args, **kwargs):
+    def __init__(self, url, dir, *args, **kwargs):
         """A svn repository.
 
         Parameters
@@ -55,7 +55,7 @@ class SubversionRepo(BaseRepo):
             self.svn_trust_cert = False
 
         self.rev = kwargs.get("rev")
-        BaseRepo.__init__(self, url, repo_dir, *args, **kwargs)
+        BaseRepo.__init__(self, url, dir, *args, **kwargs)
 
     def _user_pw_args(self):
         args = []

--- a/tests/states/test_base.py
+++ b/tests/states/test_base.py
@@ -9,7 +9,7 @@ from libvcs.states.base import BaseRepo, convert_pip_url
 
 
 def test_repr():
-    repo = create_repo(url="file://path/to/myrepo", repo_dir="/hello/", vcs="git")
+    repo = create_repo(url="file://path/to/myrepo", dir="/hello/", vcs="git")
 
     str_repo = str(repo)
     assert "GitRepo" in str_repo
@@ -18,7 +18,7 @@ def test_repr():
 
 
 def test_repr_base():
-    repo = BaseRepo(url="file://path/to/myrepo", repo_dir="/hello/")
+    repo = BaseRepo(url="file://path/to/myrepo", dir="/hello/")
 
     str_repo = str(repo)
     assert "Repo" in str_repo
@@ -28,8 +28,8 @@ def test_repr_base():
 
 def test_ensure_dir_creates_parent_if_not_exist(tmp_path: pathlib.Path):
     projects_path = tmp_path / "projects_path"  # doesn't exist yet
-    repo_dir = projects_path / "myrepo"
-    repo = BaseRepo(url="file://path/to/myrepo", repo_dir=repo_dir)
+    dir = projects_path / "myrepo"
+    repo = BaseRepo(url="file://path/to/myrepo", dir=dir)
 
     repo.ensure_dir()
     assert projects_path.is_dir()
@@ -62,7 +62,7 @@ def test_progress_callback(
 
     r = Repo(
         url=f"file://{str(git_remote_repo)}",
-        repo_dir=str(tmp_path),
+        dir=str(tmp_path),
         progress_callback=progress_cb,
     )
     r.obtain()

--- a/tests/states/test_git.py
+++ b/tests/states/test_git.py
@@ -36,16 +36,16 @@ RepoTestFactoryRemotesLazyExpected = Callable[..., GitFullRemoteDict]
     [
         [
             GitRepo,
-            lambda bare_repo_dir, tmp_path, **kwargs: {
-                "url": f"file://{bare_repo_dir}",
-                "repo_dir": tmp_path / "obtaining a bare repo",
+            lambda bare_dir, tmp_path, **kwargs: {
+                "url": f"file://{bare_dir}",
+                "dir": tmp_path / "obtaining a bare repo",
             },
         ],
         [
             create_repo_from_pip_url,
-            lambda bare_repo_dir, tmp_path, **kwargs: {
-                "pip_url": f"git+file://{bare_repo_dir}",
-                "repo_dir": tmp_path / "obtaining a bare repo",
+            lambda bare_dir, tmp_path, **kwargs: {
+                "pip_url": f"git+file://{bare_dir}",
+                "dir": tmp_path / "obtaining a bare repo",
             },
         ],
     ],
@@ -64,7 +64,7 @@ def test_repo_git_obtain_initial_commit_repo(
 
     run(["git", "init", repo_name], cwd=tmp_path)
 
-    bare_repo_dir = tmp_path / repo_name
+    bare_dir = tmp_path / repo_name
     git_repo: GitRepo = constructor(**lazy_constructor_options(**locals()))
 
     git_repo.obtain()
@@ -79,14 +79,14 @@ def test_repo_git_obtain_initial_commit_repo(
             GitRepo,
             lambda git_remote_repo, tmp_path, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": tmp_path / "myrepo",
+                "dir": tmp_path / "myrepo",
             },
         ],
         [
             create_repo_from_pip_url,
             lambda git_remote_repo, tmp_path, **kwargs: {
                 "pip_url": f"git+file://{git_remote_repo}",
-                "repo_dir": tmp_path / "myrepo",
+                "dir": tmp_path / "myrepo",
             },
         ],
     ],
@@ -114,14 +114,14 @@ def test_repo_git_obtain_full(
             GitRepo,
             lambda git_remote_repo, tmp_path, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": tmp_path / "myrepo",
+                "dir": tmp_path / "myrepo",
             },
         ],
         [
             create_repo_from_pip_url,
             lambda git_remote_repo, tmp_path, **kwargs: {
                 "pip_url": f"git+file://{git_remote_repo}",
-                "repo_dir": tmp_path / "myrepo",
+                "dir": tmp_path / "myrepo",
             },
         ],
     ],
@@ -156,7 +156,7 @@ def test_repo_update_handle_cases(
             GitRepo,
             lambda git_remote_repo, tmp_path, progress_callback, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": tmp_path / "myrepo",
+                "dir": tmp_path / "myrepo",
                 "progress_callback": progress_callback,
             },
         ],
@@ -164,7 +164,7 @@ def test_repo_update_handle_cases(
             create_repo_from_pip_url,
             lambda git_remote_repo, tmp_path, progress_callback, **kwargs: {
                 "pip_url": f"git+file://{git_remote_repo}",
-                "repo_dir": tmp_path / "myrepo",
+                "dir": tmp_path / "myrepo",
                 "progress_callback": progress_callback,
             },
         ],
@@ -202,7 +202,7 @@ def test_progress_callback(
             GitRepo,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
             },
             lambda git_remote_repo, **kwargs: {"origin": f"file://{git_remote_repo}"},
         ],
@@ -210,7 +210,7 @@ def test_progress_callback(
             GitRepo,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
                 "remotes": {"origin": f"file://{git_remote_repo}"},
             },
             lambda git_remote_repo, **kwargs: {"origin": f"file://{git_remote_repo}"},
@@ -219,7 +219,7 @@ def test_progress_callback(
             GitRepo,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
                 "remotes": {
                     "origin": f"file://{git_remote_repo}",
                     "second_remote": f"file://{git_remote_repo}",
@@ -234,7 +234,7 @@ def test_progress_callback(
             GitRepo,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
                 "remotes": {
                     "second_remote": f"file://{git_remote_repo}",
                 },
@@ -248,7 +248,7 @@ def test_progress_callback(
             GitRepo,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
                 "remotes": {
                     "origin": GitRemote(
                         name="origin",
@@ -271,7 +271,7 @@ def test_progress_callback(
             GitRepo,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
                 "remotes": {
                     "second_remote": GitRemote(
                         name="second_remote",
@@ -288,7 +288,7 @@ def test_progress_callback(
             create_repo_from_pip_url,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "pip_url": f"git+file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
             },
             lambda git_remote_repo, **kwargs: {"origin": f"file://{git_remote_repo}"},
         ],
@@ -326,7 +326,7 @@ def test_remotes(
             GitRepo,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
                 "remotes": {
                     "origin": f"file://{git_remote_repo}",
                 },
@@ -357,7 +357,7 @@ def test_remotes(
             GitRepo,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
                 "remotes": {
                     "origin": f"file://{git_remote_repo}",
                     # accepts short-hand form since it's inputted in the constructor
@@ -382,7 +382,7 @@ def test_remotes(
             GitRepo,
             lambda git_remote_repo, projects_path, repo_name, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": projects_path / repo_name,
+                "dir": projects_path / repo_name,
                 "remotes": {
                     "origin": f"file://{git_remote_repo}",
                 },
@@ -462,16 +462,16 @@ def test_git_get_url_and_rev_from_pip_url():
     [
         [
             GitRepo,
-            lambda git_remote_repo, repo_dir, **kwargs: {
+            lambda git_remote_repo, dir, **kwargs: {
                 "url": f"file://{git_remote_repo}",
-                "repo_dir": str(repo_dir),
+                "dir": str(dir),
             },
         ],
         [
             create_repo_from_pip_url,
-            lambda git_remote_repo, repo_dir, **kwargs: {
+            lambda git_remote_repo, dir, **kwargs: {
                 "pip_url": f"git+file://{git_remote_repo}",
-                "repo_dir": repo_dir,
+                "dir": dir,
             },
         ],
     ],
@@ -484,7 +484,7 @@ def test_remotes_preserves_git_ssh(
 ):
     # Regression test for #14
     repo_name = "myexamplegit"
-    repo_dir = projects_path / repo_name
+    dir = projects_path / repo_name
     remote_name = "myremote"
     remote_url = "git+ssh://git@github.com/tony/AlgoXY.git"
     git_repo: GitRepo = constructor(**lazy_constructor_options(**locals()))
@@ -504,16 +504,16 @@ def test_remotes_preserves_git_ssh(
     [
         [
             GitRepo,
-            lambda bare_repo_dir, tmp_path, **kwargs: {
-                "url": f"file://{bare_repo_dir}",
-                "repo_dir": tmp_path / "obtaining a bare repo",
+            lambda bare_dir, tmp_path, **kwargs: {
+                "url": f"file://{bare_dir}",
+                "dir": tmp_path / "obtaining a bare repo",
             },
         ],
         [
             create_repo_from_pip_url,
-            lambda bare_repo_dir, tmp_path, **kwargs: {
-                "pip_url": f"git+file://{bare_repo_dir}",
-                "repo_dir": tmp_path / "obtaining a bare repo",
+            lambda bare_dir, tmp_path, **kwargs: {
+                "pip_url": f"git+file://{bare_dir}",
+                "dir": tmp_path / "obtaining a bare repo",
             },
         ],
     ],
@@ -525,7 +525,7 @@ def test_private_ssh_format(
 ):
     pip_url_kwargs = {
         "pip_url": "git+ssh://github.com:/tmp/omg/private_ssh_repo",
-        "repo_dir": tmpdir,
+        "dir": tmpdir,
     }
 
     with pytest.raises(exc.LibVCSException) as excinfo:
@@ -735,9 +735,7 @@ def test_repo_git_remote_checkout(
 ):
     git_server = create_git_remote_repo()
     git_repo_checkout_dir = projects_path / "my_git_checkout"
-    git_repo = GitRepo(
-        repo_dir=str(git_repo_checkout_dir), url=f"file://{git_server!s}"
-    )
+    git_repo = GitRepo(dir=str(git_repo_checkout_dir), url=f"file://{git_server!s}")
 
     git_repo.obtain()
     git_repo.update_repo()

--- a/tests/states/test_hg.py
+++ b/tests/states/test_hg.py
@@ -16,7 +16,7 @@ def test_repo_mercurial(tmp_path: pathlib.Path, projects_path, hg_remote_repo):
     mercurial_repo = create_repo_from_pip_url(
         **{
             "pip_url": f"hg+file://{hg_remote_repo}",
-            "repo_dir": projects_path / repo_name,
+            "dir": projects_path / repo_name,
         }
     )
 
@@ -46,7 +46,7 @@ def test_vulnerability_2022_03_12_command_injection(
     random_dir.mkdir()
     monkeypatch.chdir(str(random_dir))
     mercurial_repo = create_repo(
-        url="--config=alias.clone=!touch ./HELLO", vcs="hg", repo_dir="./"
+        url="--config=alias.clone=!touch ./HELLO", vcs="hg", dir="./"
     )
     with pytest.raises(Exception):
         mercurial_repo.update_repo()

--- a/tests/states/test_svn.py
+++ b/tests/states/test_svn.py
@@ -19,7 +19,7 @@ def test_repo_svn(tmp_path: pathlib.Path, svn_remote_repo):
     svn_repo = create_repo_from_pip_url(
         **{
             "pip_url": f"svn+file://{svn_remote_repo}",
-            "repo_dir": tmp_path / repo_name,
+            "dir": tmp_path / repo_name,
         }
     )
 
@@ -39,9 +39,7 @@ def test_repo_svn_remote_checkout(
 ):
     svn_server = create_svn_remote_repo()
     svn_repo_checkout_dir = projects_path / "my_svn_checkout"
-    svn_repo = SubversionRepo(
-        repo_dir=svn_repo_checkout_dir, url=f"file://{svn_server!s}"
-    )
+    svn_repo = SubversionRepo(dir=svn_repo_checkout_dir, url=f"file://{svn_server!s}")
 
     svn_repo.obtain()
     svn_repo.update_repo()

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -32,7 +32,7 @@ def test_create_repo_from_pip_url(
     tmp_path: pathlib.Path, repo_dict, repo_class, raises_exception
 ):
     # add parent_dir via fixture
-    repo_dict["repo_dir"] = tmp_path / "repo_name"
+    repo_dict["dir"] = tmp_path / "repo_name"
 
     if raises_exception:
         with pytest.raises(raises_exception):
@@ -69,7 +69,7 @@ def test_create_repo_from_pip_url(
 )
 def test_create_repo(tmp_path: pathlib.Path, repo_dict, repo_class, raises_exception):
     # add parent_dir via fixture
-    repo_dict["repo_dir"] = tmp_path / "repo_name"
+    repo_dict["dir"] = tmp_path / "repo_name"
 
     if raises_exception:
         with pytest.raises(raises_exception):


### PR DESCRIPTION
`repo_dir` param is renamed to `dir`:

Before: `GitRepo(url='...', repo_dir='...')`

After: `GitRepo(url='...', dir='...')`