### PR TITLE
chore(run): Pass through to `subprocess.Popen`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,10 @@ $ pip install --user --upgrade --pre libvcs
 
 - {issue}`343`: `libvcs.cmd.core` (including {func}`~libvcs._internal.run.run`) have been moved to
   `libvcs._internal.run`. It will be supported as an unstable, internal API.
+- {issue}`361`: {class}`~libvcs._internal.run.run`'s params are now a pass-through to
+  {class}`subprocess.Popen`.
+
+  - `run(cmd, ...)` is now `run(args, ...)` to match `Popen`'s convention.
 
 ### What's new
 

--- a/libvcs/_internal/run.py
+++ b/libvcs/_internal/run.py
@@ -199,20 +199,21 @@ def run(
     check_returncode: bool = True,
     callback: Optional[ProgressCallbackProtocol] = None,
 ):
-    """Run 'cmd' in a shell and return the combined contents of stdout and
-    stderr (Blocking).  Throws an exception if the command exits non-zero.
+    """Run 'args' in a shell and return the combined contents of stdout and
+    stderr (Blocking). Throws an exception if the command exits non-zero.
+
+    Keyword arguments are passthrough to {class}`subprocess.Popen`.
 
     Parameters
     ----------
-    cmd : list or str, or single str, if shell=True
+    args : list or str, or single str, if shell=True
        the command to run
 
     shell : boolean
         boolean indicating whether we are using advanced shell
         features. Use only when absolutely necessary, since this allows a lot
         more freedom which could be exploited by malicious code. See the
-        warning here:
-        http://docs.python.org/library/subprocess.html#popen-constructor
+        warning here: http://docs.python.org/library/subprocess.html#popen-constructor
 
     cwd : str
         dir command is run from. Defaults to ``path``.

--- a/libvcs/_internal/run.py
+++ b/libvcs/_internal/run.py
@@ -150,6 +150,8 @@ def run(
     log_in_real_time: bool = True,
     check_returncode: bool = True,
     callback: Optional[ProgressCallbackProtocol] = None,
+    *args,
+    **kwargs
 ):
     """Run 'cmd' in a shell and return the combined contents of stdout and
     stderr (Blocking).  Throws an exception if the command exits non-zero.
@@ -192,6 +194,8 @@ def run(
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
         cwd=cwd,
+        *args,
+        **kwargs
     )
 
     all_output = []

--- a/libvcs/_internal/run.py
+++ b/libvcs/_internal/run.py
@@ -158,39 +158,42 @@ class ProgressCallbackProtocol(Protocol):
 if sys.platform == "win32":
     _ENV: TypeAlias = Mapping[str, str]
 else:
-    _ENV: TypeAlias = Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath]
+    _ENV: TypeAlias = Union[
+        Mapping[bytes, StrOrBytesPath], Mapping[str, StrOrBytesPath]
+    ]
 
 _CMD = Union[StrOrBytesPath, Sequence[StrOrBytesPath]]
-_FILE: TypeAlias = None | int | IO[Any]
+_FILE: TypeAlias = Optional[Union[int, IO[Any]]]
 
 
 def run(
     args: _CMD,
     bufsize: int = -1,
-    executable: StrOrBytesPath | None = None,
-    stdin: _FILE | None = None,
-    stdout: _FILE | None = None,
-    stderr: _FILE | None = None,
-    preexec_fn: Callable[[], Any] | None = None,
+    executable: Optional[StrOrBytesPath] = None,
+    stdin: Optional[_FILE] = None,
+    stdout: Optional[_FILE] = None,
+    stderr: Optional[_FILE] = None,
+    preexec_fn: Optional[Callable[[], Any]] = None,
     close_fds: bool = True,
     shell: bool = False,
-    cwd: StrOrBytesPath | None = None,
-    env: _ENV | None = None,
-    universal_newlines: bool | None = None,
-    startupinfo: Any | None = None,
+    cwd: Optional[StrOrBytesPath] = None,
+    env: Optional[_ENV] = None,
+    universal_newlines: Optional[bool] = None,
+    startupinfo: Optional[Any] = None,
     creationflags: int = 0,
     restore_signals: bool = True,
     start_new_session: bool = False,
     pass_fds: Any = (),
     *,
-    text: bool | None = None,
-    encoding: str | None = None,
-    errors: str | None = None,
-    user: str | int | None = None,
-    group: str | int | None = None,
-    extra_groups: Iterable[str | int] | None = None,
+    text: Optional[bool] = None,
+    encoding: Optional[str] = None,
+    errors: Optional[str] = None,
+    user: Optional[Union[str, int]] = None,
+    group: Optional[Union[str, int]] = None,
+    extra_groups: Optional[Iterable[Union[str, int]]] = None,
     umask: int = -1,
-    pipesize: int = -1,
+    # Not until sys.version_info >= (3, 10)
+    # pipesize: int = -1,
     # custom
     log_in_real_time: bool = True,
     check_returncode: bool = True,
@@ -256,7 +259,6 @@ def run(
         group=group,
         extra_groups=extra_groups,
         umask=umask,
-        pipesize=pipesize,
     )
 
     all_output = []

--- a/libvcs/_internal/run.py
+++ b/libvcs/_internal/run.py
@@ -23,7 +23,6 @@ from typing import (
     Protocol,
     Sequence,
     Union,
-    overload,
 )
 
 from typing_extensions import TypeAlias
@@ -164,89 +163,38 @@ else:
 _CMD = Union[StrOrBytesPath, Sequence[StrOrBytesPath]]
 _FILE: TypeAlias = None | int | IO[Any]
 
-# def run(
-#     args: _CMD,
-#     bufsize: int = -1,
-#     executable: StrOrBytesPath | None = None,
-#     stdin: _FILE | None = None,
-#     stdout: _FILE | None = None,
-#     stderr: _FILE | None = None,
-#     preexec_fn: Callable[[], Any] | None = None,
-#     close_fds: bool = True,
-#     shell: bool = False,
-#     cwd: StrOrBytesPath | None = None,
-#     env: _ENV | None = None,
-#     universal_newlines: bool = False,
-#     startupinfo: Any | None = None,
-#     creationflags: int = 0,
-#     restore_signals: bool = True,
-#     start_new_session: bool = False,
-#     pass_fds: Any = None,
-#     *,
-#     text: bool | None = None,
-#     encoding: str = "utf-8",
-#     errors: str | None = None,
-#     user: str | int | None = None,
-#     group: str | int | None = None,
-#     extra_groups: Iterable[str | int] | None = None,
-#     umask: int = -1,
-#     pipesize: int = -1,
-#
-#
-#     # custom
-#     log_in_real_time: bool = True,
-#     check_returncode: bool = True,
-#     callback: Optional[ProgressCallbackProtocol] = None,
-# ):
-
-
-@overload
-def run(
-    args: _CMD,
-    bufsize: int = ...,
-    executable: StrOrBytesPath | None = ...,
-    stdin: _FILE | None = ...,
-    stdout: _FILE | None = ...,
-    stderr: _FILE | None = ...,
-    preexec_fn: Callable[[], Any] | None = ...,
-    close_fds: bool = ...,
-    shell: bool = ...,
-    cwd: Optional[StrOrBytesPath] = ...,
-    env: _ENV | None = ...,
-    universal_newlines: bool = ...,
-    startupinfo: Any | None = ...,
-    creationflags: int = ...,
-    restore_signals: bool = ...,
-    start_new_session: bool = ...,
-    pass_fds: Any = ...,
-    *,
-    text: bool | None = ...,
-    encoding: str = "utf-8",
-    errors: str | None = ...,
-    user: str | int | None = ...,
-    group: str | int | None = ...,
-    extra_groups: Iterable[str | int] | None = ...,
-    umask: int = ...,
-    pipesize: int = ...,
-    # custom
-    log_in_real_time: bool = True,
-    check_returncode: bool = True,
-    callback: Optional[ProgressCallbackProtocol] = None,
-):
-    ...
-
 
 def run(
-    # args: Union[str, list[str]],
     args: _CMD,
+    bufsize: int = -1,
+    executable: StrOrBytesPath | None = None,
+    stdin: _FILE | None = None,
+    stdout: _FILE | None = None,
+    stderr: _FILE | None = None,
+    preexec_fn: Callable[[], Any] | None = None,
+    close_fds: bool = True,
     shell: bool = False,
-    cwd: Optional[StrOrBytesPath] = None,
+    cwd: StrOrBytesPath | None = None,
+    env: _ENV | None = None,
+    universal_newlines: bool | None = None,
+    startupinfo: Any | None = None,
+    creationflags: int = 0,
+    restore_signals: bool = True,
+    start_new_session: bool = False,
+    pass_fds: Any = (),
     *,
+    text: bool | None = None,
+    encoding: str | None = None,
+    errors: str | None = None,
+    user: str | int | None = None,
+    group: str | int | None = None,
+    extra_groups: Iterable[str | int] | None = None,
+    umask: int = -1,
+    pipesize: int = -1,
     # custom
     log_in_real_time: bool = True,
     check_returncode: bool = True,
     callback: Optional[ProgressCallbackProtocol] = None,
-    **kwargs,
 ):
     """Run 'cmd' in a shell and return the combined contents of stdout and
     stderr (Blocking).  Throws an exception if the command exits non-zero.
@@ -285,11 +233,30 @@ def run(
     """
     proc = subprocess.Popen(
         args,
+        bufsize=bufsize,
+        executable=executable,
+        stdin=stdin,
+        stdout=stdout or subprocess.PIPE,
+        stderr=stderr or subprocess.PIPE,
+        preexec_fn=preexec_fn,
+        close_fds=close_fds,
         shell=shell,
-        stderr=subprocess.PIPE,
-        stdout=subprocess.PIPE,
         cwd=cwd,
-        **kwargs,
+        env=env,
+        universal_newlines=universal_newlines,
+        startupinfo=startupinfo,
+        creationflags=creationflags,
+        restore_signals=restore_signals,
+        start_new_session=start_new_session,
+        pass_fds=pass_fds,
+        text=text,
+        encoding=encoding,
+        errors=errors,
+        user=user,
+        group=group,
+        extra_groups=extra_groups,
+        umask=umask,
+        pipesize=pipesize,
     )
 
     all_output = []

--- a/libvcs/cmd/git.py
+++ b/libvcs/cmd/git.py
@@ -181,7 +181,7 @@ class Git:
         if no_optional_locks is True:
             cli_args.append("--no-optional-locks")
 
-        return run(cmd=cli_args, **kwargs)
+        return run(args=cli_args, **kwargs)
 
     def clone(
         self,

--- a/libvcs/cmd/hg.py
+++ b/libvcs/cmd/hg.py
@@ -2,8 +2,9 @@ import enum
 import pathlib
 from typing import Optional, Sequence, Union
 
-from ..types import StrOrBytesPath, StrPath
 from libvcs._internal.run import run
+
+from ..types import StrOrBytesPath, StrPath
 
 _CMD = Union[StrOrBytesPath, Sequence[StrOrBytesPath]]
 
@@ -156,7 +157,7 @@ class Hg:
         if help is True:
             cli_args.append("--help")
 
-        return run(cmd=cli_args, **kwargs)
+        return run(args=cli_args, **kwargs)
 
     def clone(
         self,

--- a/libvcs/cmd/svn.py
+++ b/libvcs/cmd/svn.py
@@ -1,8 +1,9 @@
 import pathlib
 from typing import Literal, Optional, Sequence, Union
 
-from ..types import StrOrBytesPath, StrPath
 from libvcs._internal.run import run
+
+from ..types import StrOrBytesPath, StrPath
 
 _CMD = Union[StrOrBytesPath, Sequence[StrOrBytesPath]]
 
@@ -107,7 +108,7 @@ class Svn:
         if config_option is not None:
             cli_args.append("--config-option {config_option}")
 
-        return run(cmd=cli_args, **kwargs)
+        return run(args=cli_args, **kwargs)
 
     def checkout(
         self,


### PR DESCRIPTION
As part of us migrating to `SubprocessCommand` #340 , make existing `run()` directly compatible with `subprocess.Popen`