### PR TITLE
refactor!(projects): Make arguments kw-only

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,22 @@ $ pip install --user --upgrade --pre libvcs
 
   - `run(cmd, ...)` is now `run(args, ...)` to match `Popen`'s convention.
 
+- {issue}`364`: Project classes no longer accept positional arguments. Per [PEP 570].
+
+  Deprecated in >=0.13:
+
+  ```python
+  GitProject('https://github.com/vcs-python/libvcs.git')
+  ```
+
+  New style in >=0.13:
+
+  ```python
+  GitProject(url='https://github.com/vcs-python/libvcs.git')
+  ```
+
+  [pep 570]: https://peps.python.org/pep-0570/
+
 ### What's new
 
 - **Commands**: Experimental command wrappers added ({issue}`346`):

--- a/libvcs/projects/base.py
+++ b/libvcs/projects/base.py
@@ -4,8 +4,8 @@ import pathlib
 from typing import NamedTuple
 from urllib import parse as urlparse
 
-from libvcs.types import StrPath
 from libvcs._internal.run import CmdLoggingAdapter, mkdir_p, run
+from libvcs.types import StrPath
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class BaseProject:
     #: vcs app name, e.g. 'git'
     bin_name = ""
 
-    def __init__(self, url, dir: StrPath, progress_callback=None, *args, **kwargs):
+    def __init__(self, *, url: str, dir: StrPath, progress_callback=None, **kwargs):
         r"""
         Parameters
         ----------
@@ -111,9 +111,9 @@ class BaseProject:
         )
 
     @classmethod
-    def from_pip_url(cls, pip_url, *args, **kwargs):
+    def from_pip_url(cls, pip_url, **kwargs):
         url, rev = convert_pip_url(pip_url)
-        self = cls(url=url, rev=rev, *args, **kwargs)
+        self = cls(url=url, rev=rev, **kwargs)
 
         return self
 

--- a/libvcs/projects/git.py
+++ b/libvcs/projects/git.py
@@ -21,6 +21,8 @@ import re
 from typing import Dict, Optional, TypedDict, Union
 from urllib import parse as urlparse
 
+from libvcs.types import StrPath
+
 from .. import exc
 from .base import BaseProject, VCSLocation, convert_pip_url as base_convert_pip_url
 
@@ -154,7 +156,7 @@ class GitProject(BaseProject):
     schemes = ("git", "git+http", "git+https", "git+ssh", "git+git", "git+file")
 
     def __init__(
-        self, url: str, dir: str, remotes: GitRemotesArgs = None, *args, **kwargs
+        self, *, url: str, dir: StrPath, remotes: GitRemotesArgs = None, **kwargs
     ):
         """A git repository.
 
@@ -235,7 +237,7 @@ class GitProject(BaseProject):
                 fetch_url=url,
                 push_url=url,
             )
-        super().__init__(url, dir, *args, **kwargs)
+        super().__init__(url=url, dir=dir, **kwargs)
         self.url = self.chomp_protocol(
             (
                 self._remotes.get("origin")
@@ -245,9 +247,9 @@ class GitProject(BaseProject):
         )
 
     @classmethod
-    def from_pip_url(cls, pip_url, *args, **kwargs):
+    def from_pip_url(cls, pip_url, **kwargs):
         url, rev = convert_pip_url(pip_url)
-        self = cls(url=url, rev=rev, *args, **kwargs)
+        self = cls(url=url, rev=rev, **kwargs)
 
         return self
 

--- a/libvcs/projects/svn.py
+++ b/libvcs/projects/svn.py
@@ -20,6 +20,8 @@ import pathlib
 import re
 from urllib import parse as urlparse
 
+from libvcs.types import StrPath
+
 from .base import BaseProject, VCSLocation, convert_pip_url as base_convert_pip_url
 
 logger = logging.getLogger(__name__)
@@ -37,7 +39,7 @@ class SubversionProject(BaseProject):
     bin_name = "svn"
     schemes = ("svn", "svn+ssh", "svn+http", "svn+https", "svn+svn")
 
-    def __init__(self, url, dir, *args, **kwargs):
+    def __init__(self, *, url: str, dir: StrPath, **kwargs):
         """A svn repository.
 
         Parameters
@@ -58,7 +60,7 @@ class SubversionProject(BaseProject):
             self.svn_trust_cert = False
 
         self.rev = kwargs.get("rev")
-        super().__init__(url, dir, *args, **kwargs)
+        super().__init__(url=url, dir=dir, **kwargs)
 
     def _user_pw_args(self):
         args = []

--- a/libvcs/shortcuts.py
+++ b/libvcs/shortcuts.py
@@ -23,14 +23,14 @@ def create_project(
     True
     """
     if vcs == "git":
-        return GitProject(url, progress_callback=progress_callback, *args, **kwargs)
+        return GitProject(url=url, progress_callback=progress_callback, *args, **kwargs)
     elif vcs == "hg":
         return MercurialProject(
-            url, progress_callback=progress_callback, *args, **kwargs
+            url=url, progress_callback=progress_callback, *args, **kwargs
         )
     elif vcs == "svn":
         return SubversionProject(
-            url, progress_callback=progress_callback, *args, **kwargs
+            url=url, progress_callback=progress_callback, *args, **kwargs
         )
     else:
         raise InvalidVCS("VCS %s is not a valid VCS" % vcs)


### PR DESCRIPTION
To make passing as a configuration file (#315 and https://github.com/vcs-python/vcspull/pull/362) easier, deprecate positional arguments.

Deprecated in >=0.13:

```python
GitProject('https://github.com/vcs-python/libvcs.git')
```

New style in >=0.13:
```python
GitProject(url='https://github.com/vcs-python/libvcs.git')
```

See also:
- PEP 570: https://peps.python.org/pep-0570/
- https://peps.python.org/pep-0570/#:~:text=def%20kwd_only_arg*%2C%20arg)(%3A)