### PR TITLE
refactor!(cmd): Keyword-only params

### DIFF
--- a/libvcs/cmd/git.py
+++ b/libvcs/cmd/git.py
@@ -10,7 +10,7 @@ _CMD = Union[StrOrBytesPath, Sequence[StrOrBytesPath]]
 
 
 class Git:
-    def __init__(self, dir: StrPath):
+    def __init__(self, *, dir: StrPath):
         """Lite, typed, pythonic wrapper for git(1).
 
         Parameters
@@ -36,7 +36,7 @@ class Git:
     def run(
         self,
         args: _CMD,
-        /,
+        *,
         # Print-and-exit flags
         version: Optional[bool] = None,
         help: Optional[bool] = None,
@@ -185,6 +185,7 @@ class Git:
 
     def clone(
         self,
+        *,
         url: str,
         separate_git_dir: Optional[StrOrBytesPath] = None,
         template: Optional[str] = None,
@@ -312,6 +313,7 @@ class Git:
 
     def fetch(
         self,
+        *,
         reftag: Optional[Any] = None,
         deepen: Optional[str] = None,
         depth: Optional[str] = None,
@@ -469,6 +471,7 @@ class Git:
 
     def rebase(
         self,
+        *,
         upstream: Optional[str] = None,
         onto: Optional[str] = None,
         branch: Optional[str] = None,
@@ -665,6 +668,7 @@ class Git:
 
     def pull(
         self,
+        *,
         reftag: Optional[Any] = None,
         repository: Optional[str] = None,
         deepen: Optional[str] = None,
@@ -943,6 +947,7 @@ class Git:
 
     def init(
         self,
+        *,
         template: Optional[str] = None,
         separate_git_dir: Optional[StrOrBytesPath] = None,
         object_format: Optional[Literal["sha1", "sha256"]] = None,
@@ -1022,6 +1027,7 @@ class Git:
 
     def help(
         self,
+        *,
         all: Optional[bool] = None,
         verbose: Optional[bool] = None,
         no_external_commands: Optional[bool] = None,
@@ -1105,6 +1111,7 @@ class Git:
 
     def reset(
         self,
+        *,
         quiet: Optional[bool] = None,
         refresh: Optional[bool] = None,
         no_refresh: Optional[bool] = None,
@@ -1196,6 +1203,7 @@ class Git:
 
     def checkout(
         self,
+        *,
         quiet: Optional[bool] = None,
         progress: Optional[bool] = None,
         no_progress: Optional[bool] = None,
@@ -1329,6 +1337,7 @@ class Git:
 
     def status(
         self,
+        *,
         verbose: Optional[bool] = None,
         long: Optional[bool] = None,
         short: Optional[bool] = None,
@@ -1456,6 +1465,7 @@ class Git:
 
     def config(
         self,
+        *,
         replace_all: Optional[bool] = None,
         get: Optional[str] = None,
         get_all: Optional[bool] = None,

--- a/libvcs/cmd/hg.py
+++ b/libvcs/cmd/hg.py
@@ -25,7 +25,7 @@ class HgPagerType(enum.Enum):
 
 
 class Hg:
-    def __init__(self, dir: StrPath):
+    def __init__(self, *, dir: StrPath):
         """Lite, typed, pythonic wrapper for hg(1).
 
         Parameters
@@ -51,6 +51,7 @@ class Hg:
     def run(
         self,
         args: _CMD,
+        *,
         config: Optional[str] = None,
         repository: Optional[str] = None,
         quiet: Optional[bool] = None,
@@ -161,6 +162,7 @@ class Hg:
 
     def clone(
         self,
+        *,
         url: str,
         no_update: Optional[str] = None,
         update_rev: Optional[str] = None,

--- a/libvcs/cmd/svn.py
+++ b/libvcs/cmd/svn.py
@@ -12,7 +12,7 @@ RevisionLiteral = Union[Literal["HEAD", "BASE", "COMMITTED", "PREV"], None]
 
 
 class Svn:
-    def __init__(self, dir: StrPath):
+    def __init__(self, *, dir: StrPath):
         """Lite, typed, pythonic wrapper for svn(1).
 
         Parameters
@@ -38,6 +38,7 @@ class Svn:
     def run(
         self,
         args: _CMD,
+        *,
         quiet: Optional[bool] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,
@@ -112,6 +113,7 @@ class Svn:
 
     def checkout(
         self,
+        *,
         url: str,
         revision: Union[RevisionLiteral, str] = None,
         force: Optional[bool] = None,
@@ -159,6 +161,7 @@ class Svn:
 
     def add(
         self,
+        *,
         path: Union[list[pathlib.Path], pathlib.Path],
         targets: Optional[pathlib.Path] = None,
         depth: DepthLiteral = None,
@@ -225,7 +228,6 @@ class Svn:
         self,
         remove: Optional[str] = None,
         show_passwords: Optional[bool] = None,
-        *args,
         **kwargs,
     ):
         """
@@ -244,7 +246,7 @@ class Svn:
         >>> Svn(dir=tmp_path).auth()
         "Credentials cache in '...' is empty"
         """
-        local_flags: list[str] = [*args]
+        local_flags: list[str] = []
 
         if remove is not None:
             local_flags.extend(["--remove", remove])
@@ -256,6 +258,7 @@ class Svn:
     def blame(
         self,
         target: pathlib.Path,
+        *,
         revision: Union[RevisionLiteral, str] = None,
         verbose: Optional[bool] = None,
         force: Optional[bool] = None,
@@ -263,7 +266,6 @@ class Svn:
         incremental: Optional[bool] = None,
         xml: Optional[bool] = None,
         extensions: Optional[str] = None,
-        *args,
         **kwargs,
     ):
         """
@@ -304,7 +306,7 @@ class Svn:
         >>> svn.blame('new.txt')
         '1        ... example text'
         """
-        local_flags: list[str] = [target, *args]
+        local_flags: list[str] = [str(target)]
 
         if revision is not None:
             local_flags.append(f"--revision={revision}")
@@ -361,6 +363,7 @@ class Svn:
 
     def commit(
         self,
+        *,
         path: Union[list[pathlib.Path], pathlib.Path],
         targets: Optional[pathlib.Path] = None,
         message: Optional[str] = None,
@@ -371,7 +374,6 @@ class Svn:
         force_log: Optional[bool] = None,
         keep_changelists: Optional[bool] = None,
         include_externals: Optional[bool] = None,
-        *args,
         **kwargs,
     ):
         """


### PR DESCRIPTION
Since libvcs is <1.0, lets clamp down on positional arguments
until things are stable. Positional arguments are great, when
there's a high degree of confidence in the first arg.

We're not 100% on these as we're stubbing out endpoints rapidly at this
juncture.

See also: https://docs.python.org/3.8/whatsnew/3.8.html#positional-only-parameters