### PR TITLE
chore!(git): Remove insecure `git+git` support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ $ pip install --user --upgrade --pre libvcs
 
 ### Breaking changes
 
+- {issue}`379` Support for `git+git` URLs removed. Pip removed these in 21.0 due to them being
+  insecure [^pip-git+git]
 - {issue}`372` Typings moved from `libvcs.types` -> {mod}`libvcs._internal.types`
 - {issue}`377` Remove deprecated functions and exceptions
 
@@ -23,6 +25,8 @@ $ pip install --user --upgrade --pre libvcs
       versions by {issue}`376` / parsing utilities
     - Moved `libvcs.shortcuts.create_project()` to {func}`libvcs._internal.shortcuts.create_project`
   - Removed {exc}`libvcs.exc.InvalidPipURL`
+
+[^pip-git+git]: pip removes `git+git@` <https://github.com/pypa/pip/pull/7543>
 
 ### Fixes
 

--- a/libvcs/projects/git.py
+++ b/libvcs/projects/git.py
@@ -157,7 +157,7 @@ def convert_pip_url(pip_url: str) -> VCSLocation:
 
 class GitProject(BaseProject):
     bin_name = "git"
-    schemes = ("git", "git+http", "git+https", "git+git", "git+file")
+    schemes = ("git", "git+http", "git+https", "git+file")
     _remotes: GitProjectRemoteDict
 
     def __init__(


### PR DESCRIPTION
Deprecated since pip 21.0, insecure

See also:
- https://github.com/pypa/pip/blob/22.1.2/NEWS.rst#deprecations-and-removals-16
- https://github.com/pypa/pip/commit/eeeecbe856a6156bbab1eb319fd32849e8b11da9
- https://github.com/pypa/pip/pull/7543