### PR TITLE
chore(git): Remove another already supported netloc scheme ('git')

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -48,10 +48,12 @@ $ pip install --user --upgrade --pre libvcs
 
 ### Cleanup
 
-- :{issue}`378` Remove duplicate `uses_netloc` scheme for `git+ssh` (this was in cpython since 2.7 /
-  3.1 [^git+ssh][^python:bugs:8657])
+- {issue}`378` {issue}`380` Remove duplicate `uses_netloc` scheme for `git+ssh` (this was in cpython
+  since 2.7 / 3.1 [^git+ssh][^python:bugs:8657])
 
-[^git+ssh]: [python/cpython@ead169d]
+[^git+ssh]: `uses_netloc` added `'git'` and `'git+ssh'` in {mod}`urllib.parse`
+
+    [python/cpython@ead169d]
 
 [python/cpython@ead169d]:
   https://github.com/python/cpython/commit/ead169d3114ed0f1041b5b59ca20293449608c50

--- a/libvcs/projects/git.py
+++ b/libvcs/projects/git.py
@@ -157,7 +157,7 @@ def convert_pip_url(pip_url: str) -> VCSLocation:
 
 class GitProject(BaseProject):
     bin_name = "git"
-    schemes = ("git", "git+http", "git+https", "git+file")
+    schemes = ("git+http", "git+https", "git+file")
     _remotes: GitProjectRemoteDict
 
     def __init__(


### PR DESCRIPTION
See also:
- #378 (removes 'git+ssh')
- https://github.com/python/cpython/commit/ead169d3114ed0f1041b5b59ca20293449608c50
- https://bugs.python.org/issue8657 or
  https://github.com/python/cpython/issues/52903#issuecomment-1093501859