### PR TITLE
Parser: Support explicit matchers, critical bug fixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,7 +16,8 @@ $ pip install --user --upgrade --pre libvcs
 ### What's new
 
 - New and improved logo
-- **Parser**: Experimental VCS URL parsing added ({issue}`376`, {issue}`381`, {issue}`384`):
+- **Parser**: Experimental VCS URL parsing added ({issue}`376`, {issue}`381`, {issue}`384`,
+  {issue}`386`):
 
   VCS Parsers return {func}`dataclasses.dataclass` instances. The new tools support validation,
   parsing, mutating and exporting into URLs consumable by the VCS.

--- a/libvcs/parse/base.py
+++ b/libvcs/parse/base.py
@@ -39,7 +39,7 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
     _matchers: dict[str, Matcher] = dataclasses.field(default_factory=dict)
 
     def register(self, cls: Matcher) -> None:
-        """
+        r"""
 
         .. currentmodule:: libvcs.parse.git
 
@@ -76,11 +76,13 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
         >>> class GitHubPrefix(Matcher):
         ...     label = 'gh-prefix'
         ...     description ='Matches prefixes like github:org/repo'
-        ...     pattern = r'^github:(?P<path>)'
+        ...     pattern = r'^github:(?P<path>.*)$'
         ...     pattern_defaults = {
         ...         'hostname': 'github.com',
         ...         'scheme': 'https'
         ...     }
+        ...     # We know it's git, not any other VCS
+        ...     is_explicit = True
 
         >>> @dataclasses.dataclass(repr=False)
         ... class GitHubLocation(GitURL):
@@ -90,6 +92,21 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
 
         >>> GitHubLocation.is_valid(url='github:vcs-python/libvcs')
         True
+
+        >>> GitHubLocation.is_valid(url='github:vcs-python/libvcs', is_explicit=True)
+        True
+
+        Notice how ``pattern_defaults`` neatly fills the values for us.
+
+        >>> GitHubLocation(url='github:vcs-python/libvcs')
+        GitHubLocation(url=github:vcs-python/libvcs,
+            scheme=https,
+            hostname=github.com,
+            path=vcs-python/libvcs,
+            matcher=gh-prefix)
+
+        >>> GitHubLocation(url='github:vcs-python/libvcs').to_url()
+        'https://github.com/vcs-python/libvcs'
 
         >>> GitHubLocation.is_valid(url='gitlab:vcs-python/libvcs')
         False

--- a/libvcs/parse/base.py
+++ b/libvcs/parse/base.py
@@ -28,6 +28,8 @@ class Matcher(SkipDefaultFieldsReprMixin):
     pattern: Pattern
     """Regex pattern"""
     pattern_defaults: dict = dataclasses.field(default_factory=dict)
+    """Is the match unambiguous with other VCS systems? e.g. git+ prefix"""
+    is_explicit: bool = False
 
 
 @dataclasses.dataclass(repr=False)

--- a/libvcs/parse/base.py
+++ b/libvcs/parse/base.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Iterator, Pattern, Protocol
+from typing import Iterator, Optional, Pattern, Protocol
 
 from libvcs._internal.dataclasses import SkipDefaultFieldsReprMixin
 
@@ -13,7 +13,7 @@ class URLProtocol(Protocol):
     def to_url(self) -> str:
         ...
 
-    def is_valid(self, url: str) -> bool:
+    def is_valid(self, url: str, is_explicit: Optional[bool] = None) -> bool:
         ...
 
 

--- a/libvcs/parse/base.py
+++ b/libvcs/parse/base.py
@@ -85,33 +85,33 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
         ...     is_explicit = True
 
         >>> @dataclasses.dataclass(repr=False)
-        ... class GitHubLocation(GitURL):
+        ... class GitHubURL(GitURL):
         ...    matchers: MatcherRegistry = MatcherRegistry(
         ...        _matchers={'github_prefix': GitHubPrefix}
         ...    )
 
-        >>> GitHubLocation.is_valid(url='github:vcs-python/libvcs')
+        >>> GitHubURL.is_valid(url='github:vcs-python/libvcs')
         True
 
-        >>> GitHubLocation.is_valid(url='github:vcs-python/libvcs', is_explicit=True)
+        >>> GitHubURL.is_valid(url='github:vcs-python/libvcs', is_explicit=True)
         True
 
         Notice how ``pattern_defaults`` neatly fills the values for us.
 
-        >>> GitHubLocation(url='github:vcs-python/libvcs')
-        GitHubLocation(url=github:vcs-python/libvcs,
+        >>> GitHubURL(url='github:vcs-python/libvcs')
+        GitHubURL(url=github:vcs-python/libvcs,
             scheme=https,
             hostname=github.com,
             path=vcs-python/libvcs,
             matcher=gh-prefix)
 
-        >>> GitHubLocation(url='github:vcs-python/libvcs').to_url()
+        >>> GitHubURL(url='github:vcs-python/libvcs').to_url()
         'https://github.com/vcs-python/libvcs'
 
-        >>> GitHubLocation.is_valid(url='gitlab:vcs-python/libvcs')
+        >>> GitHubURL.is_valid(url='gitlab:vcs-python/libvcs')
         False
 
-        `GitHubLocation` sees this as invalid since it only has one matcher,
+        `GitHubURL` sees this as invalid since it only has one matcher,
         `GitHubPrefix`.
 
         >>> GitURL.is_valid(url='gitlab:vcs-python/libvcs')
@@ -135,12 +135,12 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
         Option 1: Create a brand new matcher
 
         >>> @dataclasses.dataclass(repr=False)
-        ... class GitLabLocation(GitURL):
+        ... class GitLabURL(GitURL):
         ...     matchers: MatcherRegistry = MatcherRegistry(
         ...         _matchers={'gitlab_prefix': GitLabPrefix}
         ...     )
 
-        >>> GitLabLocation.is_valid(url='gitlab:vcs-python/libvcs')
+        >>> GitLabURL.is_valid(url='gitlab:vcs-python/libvcs')
         True
 
         Option 2 (global, everywhere): Add to the global :class:`GitURL`:

--- a/libvcs/parse/base.py
+++ b/libvcs/parse/base.py
@@ -43,6 +43,7 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
 
         .. currentmodule:: libvcs.parse.git
 
+        >>> from dataclasses import dataclass
         >>> from libvcs.parse.git import GitURL, GitBaseURL
 
         :class:`GitBaseURL` - the ``git(1)`` compliant parser - won't accept a pip-style URL:
@@ -71,8 +72,9 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
         ...         'scheme': 'https'
         ...     }
 
-        >>> class GitHubLocation(GitURL):
-        ...    matchers = MatcherRegistry = MatcherRegistry(
+        >>> @dataclasses.dataclass(repr=False)
+        ... class GitHubLocation(GitURL):
+        ...    matchers: MatcherRegistry = MatcherRegistry(
         ...        _matchers={'github_prefix': GitHubPrefix}
         ...    )
 
@@ -94,10 +96,11 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
 
         Option 1: Create a brand new matcher
 
-        >>> class GitLabLocation(GitURL):
-        ...    matchers = MatcherRegistry = MatcherRegistry(
-        ...        _matchers={'gitlab_prefix': GitLabPrefix}
-        ...    )
+        >>> @dataclasses.dataclass(repr=False)
+        ... class GitLabLocation(GitURL):
+        ...     matchers: MatcherRegistry = MatcherRegistry(
+        ...         _matchers={'gitlab_prefix': GitLabPrefix}
+        ...     )
 
         >>> GitLabLocation.is_valid(url='gitlab:vcs-python/libvcs')
         True
@@ -122,7 +125,8 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
 
         >>> from libvcs.parse.git import DEFAULT_MATCHERS, PIP_DEFAULT_MATCHERS
 
-        >>> class GitURLWithPip(GitBaseURL):
+        >>> @dataclasses.dataclass(repr=False)
+        ... class GitURLWithPip(GitBaseURL):
         ...    matchers: MatcherRegistry = MatcherRegistry(
         ...        _matchers={m.label: m for m in [*DEFAULT_MATCHERS, *PIP_DEFAULT_MATCHERS]}
         ...    )

--- a/libvcs/parse/base.py
+++ b/libvcs/parse/base.py
@@ -123,7 +123,7 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
         >>> from libvcs.parse.git import DEFAULT_MATCHERS, PIP_DEFAULT_MATCHERS
 
         >>> class GitURLWithPip(GitBaseURL):
-        ...    matchers = MatcherRegistry = MatcherRegistry(
+        ...    matchers: MatcherRegistry = MatcherRegistry(
         ...        _matchers={m.label: m for m in [*DEFAULT_MATCHERS, *PIP_DEFAULT_MATCHERS]}
         ...    )
 

--- a/libvcs/parse/base.py
+++ b/libvcs/parse/base.py
@@ -112,7 +112,7 @@ class MatcherRegistry(SkipDefaultFieldsReprMixin):
         >>> GitURL.is_valid(url='gitlab:vcs-python/libvcs')
         True
 
-        git URLs + pip-style git URLs:
+        **Example: git URLs + pip-style git URLs:**
 
         This is already in :class:`GitURL` via :data:`PIP_DEFAULT_MATCHERS`. For the
         sake of showing how extensibility works, here is a recreation based on

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -215,15 +215,15 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
 
     Examples
     --------
-    >>> GitURL(url='https://github.com/vcs-python/libvcs.git')
-    GitURL(url=https://github.com/vcs-python/libvcs.git,
+    >>> GitBaseURL(url='https://github.com/vcs-python/libvcs.git')
+    GitBaseURL(url=https://github.com/vcs-python/libvcs.git,
             scheme=https,
             hostname=github.com,
             path=vcs-python/libvcs,
             suffix=.git,
             matcher=core-git-https)
 
-    >>> myrepo = GitURL(url='https://github.com/myproject/myrepo.git')
+    >>> myrepo = GitBaseURL(url='https://github.com/myproject/myrepo.git')
 
     >>> myrepo.hostname
     'github.com'
@@ -231,16 +231,16 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
     >>> myrepo.path
     'myproject/myrepo'
 
-    >>> GitURL(url='git@github.com:vcs-python/libvcs.git')
-    GitURL(url=git@github.com:vcs-python/libvcs.git,
+    >>> GitBaseURL(url='git@github.com:vcs-python/libvcs.git')
+    GitBaseURL(url=git@github.com:vcs-python/libvcs.git,
             user=git,
             hostname=github.com,
             path=vcs-python/libvcs,
             suffix=.git,
             matcher=core-git-scp)
 
-    - Compatibility checking: :meth:`GitURL.is_valid()`
-    - URLs compatible with ``git(1)``: :meth:`GitURL.to_url()`
+    - Compatibility checking: :meth:`GitBaseURL.is_valid()`
+    - URLs compatible with ``git(1)``: :meth:`GitBaseURL.to_url()`
 
     Attributes
     ----------
@@ -284,13 +284,13 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
         Examples
         --------
 
-        >>> GitURL.is_valid(url='https://github.com/vcs-python/libvcs.git')
+        >>> GitBaseURL.is_valid(url='https://github.com/vcs-python/libvcs.git')
         True
 
-        >>> GitURL.is_valid(url='git@github.com:vcs-python/libvcs.git')
+        >>> GitBaseURL.is_valid(url='git@github.com:vcs-python/libvcs.git')
         True
 
-        >>> GitURL.is_valid(url='notaurl')
+        >>> GitBaseURL.is_valid(url='notaurl')
         False
 
         **Unambiguous VCS detection**
@@ -298,12 +298,12 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
         Sometimes you may want to match a VCS exclusively, without any change for, e.g.
         in order to outright detect the VCS system being used.
 
-        >>> GitURL.is_valid(
+        >>> GitBaseURL.is_valid(
         ...     url='git@github.com:vcs-python/libvcs.git', is_explicit=True
         ... )
         False
 
-        In this case, check :meth:`GitPipURL.is_valid` or :meth:`GitURL.is_valid`'s
+        In this case, check :meth:`GitPipURL.is_valid` or :meth:`GitBaseURL.is_valid`'s
         examples.
         """
         if is_explicit is not None:
@@ -320,10 +320,10 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
         Examples
         --------
 
-        >>> git_url = GitURL(url='git@github.com:vcs-python/libvcs.git')
+        >>> git_url = GitBaseURL(url='git@github.com:vcs-python/libvcs.git')
 
         >>> git_url
-        GitURL(url=git@github.com:vcs-python/libvcs.git,
+        GitBaseURL(url=git@github.com:vcs-python/libvcs.git,
                 user=git,
                 hostname=github.com,
                 path=vcs-python/libvcs,

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -278,7 +278,7 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
                     setattr(self, k, v)
 
     @classmethod
-    def is_valid(cls, url: str) -> bool:
+    def is_valid(cls, url: str, is_explicit: Optional[bool] = None) -> bool:
         """Whether URL is compatible with VCS or not.
 
         Examples
@@ -293,6 +293,12 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
         >>> GitURL.is_valid(url='notaurl')
         False
         """
+        if is_explicit is not None:
+            return any(
+                re.search(matcher.pattern, url)
+                for matcher in cls.matchers.values()
+                if matcher.is_explicit == is_explicit
+            )
         return any(re.search(matcher.pattern, url) for matcher in cls.matchers.values())
 
     def to_url(self) -> str:

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -431,7 +431,7 @@ class GitPipURL(GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
         Examples
         --------
 
-        Will not match normal ``git(1)`` URLs, use :meth:`GitURL.is_valid` for that.
+        Will **not** match normal ``git(1)`` URLs, use :meth:`GitURL.is_valid` for that.
 
         >>> GitPipURL.is_valid(url='https://github.com/vcs-python/libvcs.git')
         False
@@ -481,6 +481,55 @@ class GitURL(GitPipURL, GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
     matchers = MatcherRegistry = MatcherRegistry(
         _matchers={m.label: m for m in [*DEFAULT_MATCHERS, *PIP_DEFAULT_MATCHERS]}
     )
+
+    @classmethod
+    def is_valid(cls, url: str, is_explicit: Optional[bool] = None) -> bool:
+        """Whether URL is compatible included Git URL matchers or not.
+
+        Examples
+        --------
+
+        **Will** match normal ``git(1)`` URLs, use :meth:`GitURL.is_valid` for that.
+
+        >>> GitURL.is_valid(url='https://github.com/vcs-python/libvcs.git')
+        True
+
+        >>> GitURL.is_valid(url='git@github.com:vcs-python/libvcs.git')
+        True
+
+        Pip-style URLs:
+
+        >>> GitURL.is_valid(url='git+https://github.com/vcs-python/libvcs.git')
+        True
+
+        >>> GitURL.is_valid(url='git+ssh://git@github.com:vcs-python/libvcs.git')
+        True
+
+        >>> GitURL.is_valid(url='notaurl')
+        False
+
+        **Explicit VCS detection**
+
+        Pip-style URLs are prefixed with the VCS name in front, so its matchers can
+        unambigously narrow the type of VCS:
+
+        >>> GitURL.is_valid(
+        ...     url='git+ssh://git@github.com:vcs-python/libvcs.git', is_explicit=True
+        ... )
+        True
+
+        Below, while it's github, that doesn't necessarily mean that the URL itself
+        is conclusively a git URL:
+
+        >>> GitURL.is_valid(
+        ...     url='git@github.com:vcs-python/libvcs.git', is_explicit=True
+        ... )
+        False
+
+        You could create a GitHub matcher that consider github.com hostnames to be
+        exclusively.
+        """
+        return super().is_valid(url=url, is_explicit=is_explicit)
 
     def to_url(self) -> str:
         """Return a ``git(1)``-compatible URL. Can be used with ``git clone``.

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -259,7 +259,7 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
     suffix: Optional[str] = None
 
     matcher: Optional[str] = None
-    matchers = MatcherRegistry = MatcherRegistry(
+    matchers: MatcherRegistry = MatcherRegistry(
         _matchers={m.label: m for m in DEFAULT_MATCHERS}
     )
 
@@ -368,7 +368,7 @@ class GitPipURL(GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
     # commit-ish (rev): tag, branch, ref
     rev: Optional[str] = None
 
-    matchers = MatcherRegistry = MatcherRegistry(
+    matchers: MatcherRegistry = MatcherRegistry(
         _matchers={m.label: m for m in PIP_DEFAULT_MATCHERS}
     )
 
@@ -478,7 +478,7 @@ class GitURL(GitPipURL, GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
       - :meth:`GitBaseURL.to_url`
     """
 
-    matchers = MatcherRegistry = MatcherRegistry(
+    matchers: MatcherRegistry = MatcherRegistry(
         _matchers={m.label: m for m in [*DEFAULT_MATCHERS, *PIP_DEFAULT_MATCHERS]}
     )
 

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -136,6 +136,7 @@ PIP_DEFAULT_MATCHERS: list[Matcher] = [
         """,
             re.VERBOSE,
         ),
+        is_explicit=True,
     ),
     Matcher(
         label="pip-scp-url",
@@ -149,6 +150,7 @@ PIP_DEFAULT_MATCHERS: list[Matcher] = [
         """,
             re.VERBOSE,
         ),
+        is_explicit=True,
     ),
     # file://, RTC 8089, File:// https://datatracker.ietf.org/doc/html/rfc8089
     Matcher(
@@ -162,6 +164,7 @@ PIP_DEFAULT_MATCHERS: list[Matcher] = [
         """,
             re.VERBOSE,
         ),
+        is_explicit=True,
     ),
 ]
 """pip-style git URLs.

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -91,7 +91,10 @@ DEFAULT_MATCHERS: list[Matcher] = [
     ),
     # SCP-style URLs, e.g. git@
 ]
-"""Core regular expressions. These are patterns understood by ``git(1)``"""
+"""Core regular expressions. These are patterns understood by ``git(1)``
+
+See also: https://git-scm.com/docs/git-clone#URLS
+"""
 
 
 #

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -292,6 +292,19 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
 
         >>> GitURL.is_valid(url='notaurl')
         False
+
+        **Unambiguous VCS detection**
+
+        Sometimes you may want to match a VCS exclusively, without any change for, e.g.
+        in order to outright detect the VCS system being used.
+
+        >>> GitURL.is_valid(
+        ...     url='git@github.com:vcs-python/libvcs.git', is_explicit=True
+        ... )
+        False
+
+        In this case, check :meth:`GitPipURL.is_valid` or :meth:`GitURL.is_valid`'s
+        examples.
         """
         if is_explicit is not None:
             return any(
@@ -410,6 +423,44 @@ class GitPipURL(GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
             url = f"{url}@{self.rev}"
 
         return url
+
+    @classmethod
+    def is_valid(cls, url: str, is_explicit: Optional[bool] = None) -> bool:
+        """Whether URL is compatible with Pip Git's VCS URL pattern or not.
+
+        Examples
+        --------
+
+        Will not match normal ``git(1)`` URLs, use :meth:`GitURL.is_valid` for that.
+
+        >>> GitPipURL.is_valid(url='https://github.com/vcs-python/libvcs.git')
+        False
+
+        >>> GitPipURL.is_valid(url='git@github.com:vcs-python/libvcs.git')
+        False
+
+        Pip-style URLs:
+
+        >>> GitPipURL.is_valid(url='git+https://github.com/vcs-python/libvcs.git')
+        True
+
+        >>> GitPipURL.is_valid(url='git+ssh://git@github.com:vcs-python/libvcs.git')
+        True
+
+        >>> GitPipURL.is_valid(url='notaurl')
+        False
+
+        **Explicit VCS detection**
+
+        Pip-style URLs are prefixed with the VCS name in front, so its matchers can
+        unambigously narrow the type of VCS:
+
+        >>> GitPipURL.is_valid(
+        ...     url='git+ssh://git@github.com:vcs-python/libvcs.git', is_explicit=True
+        ... )
+        True
+        """
+        return super().is_valid(url=url, is_explicit=is_explicit)
 
 
 @dataclasses.dataclass(repr=False)

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -275,10 +275,11 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
             groups = match.groupdict()
             setattr(self, "matcher", matcher.label)
             for k, v in groups.items():
-                if v is None and k in matcher.pattern_defaults:
-                    setattr(self, k, matcher.pattern_defaults[v])
-                else:
-                    setattr(self, k, v)
+                setattr(self, k, v)
+
+            for k, v in matcher.pattern_defaults.items():
+                if getattr(self, k, None) is None:
+                    setattr(self, k, matcher.pattern_defaults[k])
 
     @classmethod
     def is_valid(cls, url: str, is_explicit: Optional[bool] = None) -> bool:

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -484,7 +484,7 @@ class GitURL(GitPipURL, GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
 
     @classmethod
     def is_valid(cls, url: str, is_explicit: Optional[bool] = None) -> bool:
-        """Whether URL is compatible included Git URL matchers or not.
+        r"""Whether URL is compatible included Git URL matchers or not.
 
         Examples
         --------
@@ -527,7 +527,38 @@ class GitURL(GitPipURL, GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
         False
 
         You could create a GitHub matcher that consider github.com hostnames to be
-        exclusively.
+        exclusively git:
+
+        >>> GitHubMatcher = Matcher(
+        ...     # Since github.com exclusively serves git repos, make explicit
+        ...     label='gh-matcher',
+        ...     description='Matches github.com https URLs, exact VCS match',
+        ...     pattern=re.compile(
+        ...         rf'''
+        ...         ^(?P<scheme>ssh)?
+        ...         ((?P<user>\w+)@)?
+        ...         (?P<hostname>(github.com)+):
+        ...         (?P<path>(\w[^:]+))
+        ...         {RE_SUFFIX}?
+        ...         ''',
+        ...         re.VERBOSE,
+        ...     ),
+        ...     is_explicit=True,
+        ...     pattern_defaults={
+        ...         'hostname': 'github.com'
+        ...     }
+        ... )
+
+        >>> GitURL.matchers.register(GitHubMatcher)
+
+        >>> GitURL.is_valid(
+        ...     url='git@github.com:vcs-python/libvcs.git', is_explicit=True
+        ... )
+        True
+
+        This is just us cleaning up:
+
+        >>> GitURL.matchers.unregister('gh-matcher')
         """
         return super().is_valid(url=url, is_explicit=is_explicit)
 
@@ -538,12 +569,12 @@ class GitURL(GitPipURL, GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
         --------
 
         SSH style URL:
-        >>> git_url = GitURL(url='git@github.com:vcs-python/libvcs.git')
+        >>> git_url = GitURL(url='git@github.com:vcs-python/libvcs')
 
         >>> git_url.path = 'vcs-python/vcspull'
 
         >>> git_url.to_url()
-        'git@github.com:vcs-python/vcspull.git'
+        'git@github.com:vcs-python/vcspull'
 
         HTTPs URL:
 

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -430,3 +430,57 @@ class GitURL(GitPipURL, GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
     matchers = MatcherRegistry = MatcherRegistry(
         _matchers={m.label: m for m in [*DEFAULT_MATCHERS, *PIP_DEFAULT_MATCHERS]}
     )
+
+    def to_url(self) -> str:
+        """Return a ``git(1)``-compatible URL. Can be used with ``git clone``.
+
+        Examples
+        --------
+
+        SSH style URL:
+        >>> git_location = GitURL(url='git@github.com:vcs-python/libvcs.git')
+
+        >>> git_location.path = 'vcs-python/vcspull'
+
+        >>> git_location.to_url()
+        'git@github.com:vcs-python/vcspull.git'
+
+        HTTPs URL:
+
+        >>> git_location = GitURL(url='https://github.com/vcs-python/libvcs.git')
+
+        >>> git_location.path = 'vcs-python/vcspull'
+
+        >>> git_location.to_url()
+        'https://github.com/vcs-python/vcspull.git'
+
+        Switch them to gitlab:
+
+        >>> git_location.hostname = 'gitlab.com'
+
+        >>> git_location.to_url()
+        'https://gitlab.com/vcs-python/vcspull.git'
+
+        Pip style URL, thanks to this class implementing :class:`GitPipURL`:
+
+        >>> git_location = GitURL(url='git+ssh://git@github.com/vcs-python/libvcs')
+
+        >>> git_location.hostname = 'gitlab.com'
+
+        >>> git_location.to_url()
+        'git+ssh://gitlab.com/vcs-python/libvcs'
+
+        See also
+        --------
+
+        :meth:`GitBaseURL.to_url`, :meth:`GitPipURL.to_url`
+        """
+        if self.scheme is not None:
+            parts = [self.scheme, "://", self.hostname, "/", self.path]
+        else:
+            parts = [self.user or "git", "@", self.hostname, ":", self.path]
+
+        if self.suffix:
+            parts.append(self.suffix)
+
+        return "".join(part for part in parts if isinstance(part, str))

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -35,7 +35,7 @@ SCP_REGEX = r"""
     # The server-side path. e.g. 'user/project.git'. Must start with an
     # alphanumeric character so as not to be confusable with a Windows paths
     # like 'C:/foo/bar' or 'C:\foo\bar'.
-    (?P<path>(\w[^:]+))
+    (?P<path>(\w[^:.]+))
     """
 
 RE_PATH = r"""
@@ -83,7 +83,7 @@ DEFAULT_MATCHERS: list[Matcher] = [
             rf"""
         ^(?P<scheme>ssh)?
         {SCP_REGEX}
-        {RE_SUFFIX}
+        {RE_SUFFIX}?
         """,
             re.VERBOSE,
         ),

--- a/libvcs/parse/git.py
+++ b/libvcs/parse/git.py
@@ -307,9 +307,9 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
         Examples
         --------
 
-        >>> git_location = GitURL(url='git@github.com:vcs-python/libvcs.git')
+        >>> git_url = GitURL(url='git@github.com:vcs-python/libvcs.git')
 
-        >>> git_location
+        >>> git_url
         GitURL(url=git@github.com:vcs-python/libvcs.git,
                 user=git,
                 hostname=github.com,
@@ -319,16 +319,16 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
 
         Switch repo libvcs -> vcspull:
 
-        >>> git_location.path = 'vcs-python/vcspull'
+        >>> git_url.path = 'vcs-python/vcspull'
 
-        >>> git_location.to_url()
+        >>> git_url.to_url()
         'git@github.com:vcs-python/vcspull.git'
 
         Switch them to gitlab:
 
-        >>> git_location.hostname = 'gitlab.com'
+        >>> git_url.hostname = 'gitlab.com'
 
-        >>> git_location.to_url()
+        >>> git_url.to_url()
         'git@gitlab.com:vcs-python/vcspull.git'
 
         todo
@@ -365,11 +365,11 @@ class GitPipURL(GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
         Examples
         --------
 
-        >>> git_location = GitPipURL(
+        >>> git_url = GitPipURL(
         ...     url='git+ssh://git@bitbucket.example.com:7999/PROJ/repo.git'
         ... )
 
-        >>> git_location
+        >>> git_url
         GitPipURL(url=git+ssh://git@bitbucket.example.com:7999/PROJ/repo.git,
                 scheme=git+ssh,
                 user=git,
@@ -379,18 +379,18 @@ class GitPipURL(GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
                 suffix=.git,
                 matcher=pip-url)
 
-        >>> git_location.path = 'libvcs/vcspull'
+        >>> git_url.path = 'libvcs/vcspull'
 
-        >>> git_location.to_url()
+        >>> git_url.to_url()
         'git+ssh://bitbucket.example.com/libvcs/vcspull.git'
 
         It also accepts revisions, e.g. branch, tag, ref:
 
-        >>> git_location = GitPipURL(
+        >>> git_url = GitPipURL(
         ...     url='git+https://github.com/vcs-python/libvcs.git@v0.10.0'
         ... )
 
-        >>> git_location
+        >>> git_url
         GitPipURL(url=git+https://github.com/vcs-python/libvcs.git@v0.10.0,
                 scheme=git+https,
                 hostname=github.com,
@@ -399,9 +399,9 @@ class GitPipURL(GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
                 matcher=pip-url,
                 rev=v0.10.0)
 
-        >>> git_location.path = 'libvcs/vcspull'
+        >>> git_url.path = 'libvcs/vcspull'
 
-        >>> git_location.to_url()
+        >>> git_url.to_url()
         'git+https://github.com/libvcs/vcspull.git@v0.10.0'
         """
         url = super().to_url()
@@ -438,36 +438,36 @@ class GitURL(GitPipURL, GitBaseURL, URLProtocol, SkipDefaultFieldsReprMixin):
         --------
 
         SSH style URL:
-        >>> git_location = GitURL(url='git@github.com:vcs-python/libvcs.git')
+        >>> git_url = GitURL(url='git@github.com:vcs-python/libvcs.git')
 
-        >>> git_location.path = 'vcs-python/vcspull'
+        >>> git_url.path = 'vcs-python/vcspull'
 
-        >>> git_location.to_url()
+        >>> git_url.to_url()
         'git@github.com:vcs-python/vcspull.git'
 
         HTTPs URL:
 
-        >>> git_location = GitURL(url='https://github.com/vcs-python/libvcs.git')
+        >>> git_url = GitURL(url='https://github.com/vcs-python/libvcs.git')
 
-        >>> git_location.path = 'vcs-python/vcspull'
+        >>> git_url.path = 'vcs-python/vcspull'
 
-        >>> git_location.to_url()
+        >>> git_url.to_url()
         'https://github.com/vcs-python/vcspull.git'
 
         Switch them to gitlab:
 
-        >>> git_location.hostname = 'gitlab.com'
+        >>> git_url.hostname = 'gitlab.com'
 
-        >>> git_location.to_url()
+        >>> git_url.to_url()
         'https://gitlab.com/vcs-python/vcspull.git'
 
         Pip style URL, thanks to this class implementing :class:`GitPipURL`:
 
-        >>> git_location = GitURL(url='git+ssh://git@github.com/vcs-python/libvcs')
+        >>> git_url = GitURL(url='git+ssh://git@github.com/vcs-python/libvcs')
 
-        >>> git_location.hostname = 'gitlab.com'
+        >>> git_url.hostname = 'gitlab.com'
 
-        >>> git_location.to_url()
+        >>> git_url.to_url()
         'git+ssh://gitlab.com/vcs-python/libvcs'
 
         See also

--- a/libvcs/parse/hg.py
+++ b/libvcs/parse/hg.py
@@ -195,7 +195,7 @@ class HgURL(URLProtocol, SkipDefaultFieldsReprMixin):
                     setattr(self, k, v)
 
     @classmethod
-    def is_valid(cls, url: str) -> bool:
+    def is_valid(cls, url: str, is_explicit: Optional[bool] = False) -> bool:
         """Whether URL is compatible with VCS or not.
 
         Examples

--- a/libvcs/parse/hg.py
+++ b/libvcs/parse/hg.py
@@ -189,10 +189,11 @@ class HgURL(URLProtocol, SkipDefaultFieldsReprMixin):
             groups = match.groupdict()
             setattr(self, "matcher", matcher.label)
             for k, v in groups.items():
-                if v is None and k in matcher.pattern_defaults:
-                    setattr(self, k, matcher.pattern_defaults[v])
-                else:
-                    setattr(self, k, v)
+                setattr(self, k, v)
+
+            for k, v in matcher.pattern_defaults.items():
+                if getattr(self, k, None) is None:
+                    setattr(self, k, matcher.pattern_defaults[k])
 
     @classmethod
     def is_valid(cls, url: str, is_explicit: Optional[bool] = False) -> bool:

--- a/libvcs/parse/hg.py
+++ b/libvcs/parse/hg.py
@@ -176,7 +176,7 @@ class HgURL(URLProtocol, SkipDefaultFieldsReprMixin):
 
     matcher: Optional[str] = None
     # name of the :class:`Matcher`
-    matchers = MatcherRegistry = MatcherRegistry(
+    matchers: MatcherRegistry = MatcherRegistry(
         _matchers={m.label: m for m in DEFAULT_MATCHERS}
     )
 

--- a/libvcs/parse/hg.py
+++ b/libvcs/parse/hg.py
@@ -220,9 +220,9 @@ class HgURL(URLProtocol, SkipDefaultFieldsReprMixin):
         Examples
         --------
 
-        >>> hg_location = HgURL(url='https://hg.mozilla.org/mozilla-central')
+        >>> hg_url = HgURL(url='https://hg.mozilla.org/mozilla-central')
 
-        >>> hg_location
+        >>> hg_url
         HgURL(url=https://hg.mozilla.org/mozilla-central,
                 scheme=https,
                 hostname=hg.mozilla.org,
@@ -231,17 +231,17 @@ class HgURL(URLProtocol, SkipDefaultFieldsReprMixin):
 
         Switch repo libvcs -> vcspull:
 
-        >>> hg_location.path = 'mobile-browser'
+        >>> hg_url.path = 'mobile-browser'
 
-        >>> hg_location.to_url()
+        >>> hg_url.to_url()
         'https://hg.mozilla.org/mobile-browser'
 
         Switch them to localhost:
 
-        >>> hg_location.hostname = 'localhost'
-        >>> hg_location.scheme = 'http'
+        >>> hg_url.hostname = 'localhost'
+        >>> hg_url.scheme = 'http'
 
-        >>> hg_location.to_url()
+        >>> hg_url.to_url()
         'http://localhost/mobile-browser'
 
         Another example, `hugin <http://hugin.hg.sourceforge.net>`_:

--- a/libvcs/parse/svn.py
+++ b/libvcs/parse/svn.py
@@ -183,10 +183,11 @@ class SvnURL(URLProtocol, SkipDefaultFieldsReprMixin):
             groups = match.groupdict()
             setattr(self, "matcher", matcher.label)
             for k, v in groups.items():
-                if v is None and k in matcher.pattern_defaults:
-                    setattr(self, k, matcher.pattern_defaults[v])
-                else:
-                    setattr(self, k, v)
+                setattr(self, k, v)
+
+            for k, v in matcher.pattern_defaults.items():
+                if getattr(self, k, None) is None:
+                    setattr(self, k, matcher.pattern_defaults[k])
 
     @classmethod
     def is_valid(cls, url: str, is_explicit: Optional[bool] = False) -> bool:

--- a/libvcs/parse/svn.py
+++ b/libvcs/parse/svn.py
@@ -189,7 +189,7 @@ class SvnURL(URLProtocol, SkipDefaultFieldsReprMixin):
                     setattr(self, k, v)
 
     @classmethod
-    def is_valid(cls, url: str) -> bool:
+    def is_valid(cls, url: str, is_explicit: Optional[bool] = False) -> bool:
         """Whether URL is compatible with VCS or not.
 
         Examples

--- a/libvcs/parse/svn.py
+++ b/libvcs/parse/svn.py
@@ -211,11 +211,11 @@ class SvnURL(URLProtocol, SkipDefaultFieldsReprMixin):
         Examples
         --------
 
-        >>> svn_location = SvnURL(
+        >>> svn_url = SvnURL(
         ...     url='svn+ssh://my-username@my-server/vcs-python/libvcs'
         ... )
 
-        >>> svn_location
+        >>> svn_url
         SvnURL(url=svn+ssh://my-username@my-server/vcs-python/libvcs,
                 scheme=svn+ssh,
                 user=my-username,
@@ -225,16 +225,16 @@ class SvnURL(URLProtocol, SkipDefaultFieldsReprMixin):
 
         Switch repo libvcs -> vcspull:
 
-        >>> svn_location.path = 'vcs-python/vcspull'
+        >>> svn_url.path = 'vcs-python/vcspull'
 
-        >>> svn_location.to_url()
+        >>> svn_url.to_url()
         'svn+ssh://my-username@my-server/vcs-python/vcspull'
 
         Switch user to "tom":
 
-        >>> svn_location.user = 'tom'
+        >>> svn_url.user = 'tom'
 
-        >>> svn_location.to_url()
+        >>> svn_url.to_url()
         'svn+ssh://tom@my-server/vcs-python/vcspull'
         """
         parts = [self.scheme or "ssh", "://"]

--- a/tests/parse/test_git.py
+++ b/tests/parse/test_git.py
@@ -142,7 +142,7 @@ def test_git_url_extension_pip(
     git_repo: GitProject,
 ):
     class GitURLWithPip(GitBaseURL):
-        matchers = MatcherRegistry = MatcherRegistry(
+        matchers: MatcherRegistry = MatcherRegistry(
             _matchers={m.label: m for m in [*DEFAULT_MATCHERS, *PIP_DEFAULT_MATCHERS]}
         )
 
@@ -255,7 +255,7 @@ def test_git_revs(
     git_url_kwargs: GitURLKwargs,
 ):
     class GitURLWithPip(GitURL):
-        matchers = MatcherRegistry = MatcherRegistry(
+        matchers: MatcherRegistry = MatcherRegistry(
             _matchers={m.label: m for m in [*DEFAULT_MATCHERS, *PIP_DEFAULT_MATCHERS]}
         )
 

--- a/tests/parse/test_hg.py
+++ b/tests/parse/test_hg.py
@@ -107,7 +107,7 @@ def test_hg_url_extension_pip(
     hg_repo: MercurialProject,
 ):
     class HgURLWithPip(HgURL):
-        matchers = MatcherRegistry = MatcherRegistry(
+        matchers: MatcherRegistry = MatcherRegistry(
             _matchers={m.label: m for m in [*DEFAULT_MATCHERS, *PIP_DEFAULT_MATCHERS]}
         )
 

--- a/tests/parse/test_svn.py
+++ b/tests/parse/test_svn.py
@@ -124,7 +124,7 @@ def test_svn_url_extension_pip(
     svn_repo: SubversionProject,
 ):
     class SvnURLWithPip(SvnURL):
-        matchers = MatcherRegistry = MatcherRegistry(
+        matchers: MatcherRegistry = MatcherRegistry(
             _matchers={m.label: m for m in [*DEFAULT_MATCHERS, *PIP_DEFAULT_MATCHERS]}
         )
 


### PR DESCRIPTION
Parser:

- Git scp-style URLs: Fix detection detect of scp style URLs with `.git` prefixes
- Fix critical bug where `matchers` were being applied as variable not annotations
- Fix `pattern_defaults`
- Base tests: Rename `Location` to `URL`
- Tests and modules: Rename `_location` to `_url`