### PR TITLE
fix(git): Fix update_repo when there are untracked files

### DIFF
--- a/src/libvcs/sync/git.py
+++ b/src/libvcs/sync/git.py
@@ -418,9 +418,9 @@ class GitSync(BaseSync):
             # to be able to perform git pull --rebase
             if need_stash:
                 # If Git < 1.7.6, uses --quiet --all
-                git_stash_save_options = "--quiet"
+                git_stash_save_options = ["--quiet", "--include-untracked"]
                 try:
-                    process = self.run(["stash", "save", git_stash_save_options])
+                    process = self.run(["stash", "save"] + git_stash_save_options)
                 except exc.CommandError:
                     self.log.error("Failed to stash changes")
 


### PR DESCRIPTION
Fixes #395

I went with the adding `--include-untracked` to `git stash save` route. That way if there are conflicts the rebase will still be performed.

Let me know if that's how I should make the tests (my Python is quite rusty) or if you have any other comments.

I can make the backport PR once this is approved.