### PR TITLE
Registry examples

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,18 @@ $ pip install --user --upgrade --pre libvcs
 
 - _Add your latest changes from PRs here_
 
+### New features
+
+#### URLs
+
+- Added `weight` to matchers (#428)
+
+  - More heavily weighted matcher will have preference over others
+  - Fixes an issue where `defaults` would be overwritten
+
+    The first, highest weighted will "win", avoiding the recursion causing defau defaults for other
+    matchers to be applied.
+
 ## libvcs 0.17.0 (2022-09-25)
 
 ### New features

--- a/docs/url/registry.md
+++ b/docs/url/registry.md
@@ -2,6 +2,8 @@
 
 Detect VCS from `git`, `hg`, and `svn` URLs.
 
+**Basic example:**
+
 ```python
 >>> from libvcs.url.registry import registry, ParserMatch
 >>> from libvcs.url.git import GitURL
@@ -20,6 +22,87 @@ Detect VCS from `git`, `hg`, and `svn` URLs.
 
 >>> registry.match('git+ssh://git@invent.kde.org:plasma/plasma-sdk.git', is_explicit=True)
 [ParserMatch(vcs='git', match=GitURL(...))]
+```
+
+**From the ground up:**
+
+```python
+>>> import dataclasses
+>>> from libvcs.url.base import Rule, RuleMap
+>>> from libvcs.url.registry import ParserMatch, VCSRegistry
+>>> from libvcs.url.git import GitURL
+
+This will match `github:org/repo`:
+
+>>> class GitHubPrefix(Rule):
+...     label = 'gh-prefix'
+...     description ='Matches prefixes like github:org/repo'
+...     pattern = r'^github:(?P<path>.*)$'
+...     defaults = {
+...         'hostname': 'github.com',
+...         'scheme': 'https'
+...     }
+...     is_explicit = True  # We know it's git, not any other VCS
+
+Prefix for KDE infrastructure, `kde:group/repository`:
+
+>>> class KDEPrefix(Rule):  # https://community.kde.org/Infrastructure/Git
+...     label = 'kde-prefix'
+...     description ='Matches prefixes like kde:org/repo'
+...     pattern = r'^kde:(?P<path>\w[^:]+)$'
+...     defaults = {
+...         'hostname': 'invent.kde.org',
+...         'scheme': 'https'
+...     }
+...     is_explicit = True
+
+>>> @dataclasses.dataclass(repr=False)
+... class MyGitURLParser(GitURL):
+...    rule_map: RuleMap = RuleMap(
+...        _rule_map={
+...            **GitURL.rule_map._rule_map,
+...            'github_prefix': GitHubPrefix,
+...            'kde_prefix': KDEPrefix,
+...        }
+...    )
+
+>>> my_parsers: "ParserLazyMap" = {
+...    "git": MyGitURLParser,
+...    "hg": "libvcs.url.hg.HgURL",
+...    "svn": "libvcs.url.svn.SvnURL",
+... }
+
+>>> vcs_matcher = VCSRegistry(parsers=my_parsers)
+
+>>> vcs_matcher.match('git@invent.kde.org:plasma/plasma-sdk.git')
+[ParserMatch(vcs='git', match=MyGitURLParser(...)),
+    ParserMatch(vcs='hg', match=HgURL(...)),
+    ParserMatch(vcs='svn', match=SvnURL(...))]
+
+Still works with everything GitURL does:
+
+>>> vcs_matcher.match('git+ssh://git@invent.kde.org:plasma/plasma-sdk.git', is_explicit=True)
+[ParserMatch(vcs='git', match=MyGitURLParser(...))]
+
+>>> vcs_matcher.match('github:webpack/webpack', is_explicit=True)
+[ParserMatch(vcs='git',
+    match=MyGitURLParser(url=github:webpack/webpack,
+    hostname=github.com,
+    path=webpack/webpack,
+    rule=gh-prefix))]
+
+>>> vcs_matcher.match('github:webpack/webpack', is_explicit=True)[0].match.to_url()
+'git@github.com:webpack/webpack'
+
+>>> vcs_matcher.match('kde:frameworks/kirigami', is_explicit=True)
+[ParserMatch(vcs='git',
+    match=MyGitURLParser(url=kde:frameworks/kirigami,
+    hostname=invent.kde.org,
+    path=frameworks/kirigami,
+    rule=kde-prefix))]
+
+>>> vcs_matcher.match('kde:frameworks/kirigami', is_explicit=True)[0].match.to_url()
+'git@invent.kde.org:frameworks/kirigami'
 ```
 
 ```{eval-rst}

--- a/docs/url/registry.md
+++ b/docs/url/registry.md
@@ -43,6 +43,7 @@ This will match `github:org/repo`:
 ...         'scheme': 'https'
 ...     }
 ...     is_explicit = True  # We know it's git, not any other VCS
+...     weight = 100
 
 Prefix for KDE infrastructure, `kde:group/repository`:
 
@@ -55,6 +56,7 @@ Prefix for KDE infrastructure, `kde:group/repository`:
 ...         'scheme': 'https'
 ...     }
 ...     is_explicit = True
+...     weight = 100
 
 >>> @dataclasses.dataclass(repr=False)
 ... class MyGitURLParser(GitURL):
@@ -87,21 +89,46 @@ Still works with everything GitURL does:
 >>> vcs_matcher.match('github:webpack/webpack', is_explicit=True)
 [ParserMatch(vcs='git',
     match=MyGitURLParser(url=github:webpack/webpack,
+    scheme=https,
     hostname=github.com,
     path=webpack/webpack,
     rule=gh-prefix))]
 
->>> vcs_matcher.match('github:webpack/webpack', is_explicit=True)[0].match.to_url()
+>>> git_match = vcs_matcher.match('github:webpack/webpack', is_explicit=True)[0].match
+
+>>> git_match.to_url()
+'https://github.com/webpack/webpack'
+
+If an ssh URL is preferred:
+
+>>> git_match.scheme = None
+
+>>> git_match.to_url()
 'git@github.com:webpack/webpack'
 
 >>> vcs_matcher.match('kde:frameworks/kirigami', is_explicit=True)
 [ParserMatch(vcs='git',
     match=MyGitURLParser(url=kde:frameworks/kirigami,
+    scheme=https,
     hostname=invent.kde.org,
     path=frameworks/kirigami,
     rule=kde-prefix))]
 
->>> vcs_matcher.match('kde:frameworks/kirigami', is_explicit=True)[0].match.to_url()
+>>> kde_match = vcs_matcher.match('kde:frameworks/kirigami', is_explicit=True)[0].match
+
+>>> kde_match
+MyGitURLParser(url=kde:frameworks/kirigami,
+    scheme=https,
+    hostname=invent.kde.org,
+    path=frameworks/kirigami,
+    rule=kde-prefix)
+
+>>> kde_match.to_url()
+'https://invent.kde.org/frameworks/kirigami'
+
+>>> kde_match.scheme = None
+
+>>> kde_match.to_url()
 'git@invent.kde.org:frameworks/kirigami'
 ```
 

--- a/src/libvcs/url/base.py
+++ b/src/libvcs/url/base.py
@@ -36,6 +36,8 @@ class Rule(SkipDefaultFieldsReprMixin):
     defaults: dict[str, str] = dataclasses.field(default_factory=dict)
     """Is the match unambiguous with other VCS systems? e.g. git+ prefix"""
     is_explicit: bool = False
+    """Weight: Higher is more likely to win"""
+    weight: int = 0
 
 
 @dataclasses.dataclass(repr=False)
@@ -95,6 +97,7 @@ class RuleMap(SkipDefaultFieldsReprMixin):
         ...     }
         ...     # We know it's git, not any other VCS
         ...     is_explicit = True
+        ...     weight = 50
 
         >>> @dataclasses.dataclass(repr=False)
         ... class GitHubURL(GitURL):

--- a/src/libvcs/url/git.py
+++ b/src/libvcs/url/git.py
@@ -277,7 +277,7 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
                 setattr(self, k, v)
 
             for k, v in rule.defaults.items():
-                if getattr(self, k, None) is None:
+                if getattr(self, k, None) is not None:
                     setattr(self, k, rule.defaults[k])
 
     @classmethod

--- a/src/libvcs/url/git.py
+++ b/src/libvcs/url/git.py
@@ -274,7 +274,8 @@ class GitBaseURL(URLProtocol, SkipDefaultFieldsReprMixin):
             groups = match.groupdict()
             setattr(self, "rule", rule.label)
             for k, v in groups.items():
-                setattr(self, k, v)
+                if v is not None:
+                    setattr(self, k, v)
 
             for k, v in rule.defaults.items():
                 if getattr(self, k, None) is not None:

--- a/tests/url/test_git.py
+++ b/tests/url/test_git.py
@@ -64,7 +64,6 @@ TEST_FIXTURES: list[GitURLFixture] = [
         is_valid=True,
         git_url=GitURL(
             url="git@github.com:vcs-python/libvcs.git",
-            scheme="https",
             hostname="github.com",
             path="vcs-python/libvcs",
         ),
@@ -200,7 +199,7 @@ class ToURLFixture(typing.NamedTuple):
             ),
         ),
         ToURLFixture(
-            expected="git@github.com:vcs-python/libvcs.git",
+            expected="https://github.com/vcs-python/libvcs.git",
             git_url=GitURL(
                 url="git@github.com:vcs-python/libvcs.git",
                 scheme="https",


### PR DESCRIPTION
This example found that the `defaults` will get overwritten by a URL running through all matchers. It should only use the defaults of the one ultimately being picked

And how do we pick the "best" one?