### PR TITLE
subprocess: Backport typeshed typings

### DIFF
--- a/src/libvcs/_internal/subprocess.py
+++ b/src/libvcs/_internal/subprocess.py
@@ -42,7 +42,7 @@ Examples
 import dataclasses
 import subprocess
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Collection, Mapping, Sequence
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -197,7 +197,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     # POSIX-only
     restore_signals: bool = True
     start_new_session: bool = False
-    pass_fds: Any = ()
+    pass_fds: Collection[int] = ()
     umask: int = -1
     if sys.version_info >= (3, 10):
         pipesize: int = -1

--- a/src/libvcs/_internal/subprocess.py
+++ b/src/libvcs/_internal/subprocess.py
@@ -219,7 +219,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     def Popen(
         self,
         args: Optional[_CMD] = ...,
-        universal_newlines: bool = ...,
+        universal_newlines: Optional[bool] = ...,
         *,
         text: Optional[bool] = ...,
         encoding: str,
@@ -230,7 +230,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     def Popen(
         self,
         args: Optional[_CMD] = ...,
-        universal_newlines: bool = ...,
+        universal_newlines: Optional[bool] = ...,
         *,
         text: Optional[bool] = ...,
         encoding: Optional[str] = ...,
@@ -253,7 +253,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     def Popen(
         self,
         args: Optional[_CMD] = ...,
-        universal_newlines: bool = ...,
+        universal_newlines: Optional[bool] = ...,
         *,
         text: Literal[True],
         encoding: Optional[str] = ...,
@@ -264,7 +264,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     def Popen(
         self,
         args: Optional[_CMD] = ...,
-        universal_newlines: Literal[False] = ...,
+        universal_newlines: Literal[False, None] = ...,
         *,
         text: Literal[None, False] = ...,
         encoding: None = ...,
@@ -325,7 +325,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     @overload
     def check_output(
         self,
-        universal_newlines: bool = ...,
+        universal_newlines: Optional[bool] = ...,
         *,
         input: Optional[Union[str, bytes]] = ...,
         encoding: Optional[str] = ...,
@@ -349,7 +349,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     @overload
     def check_output(
         self,
-        universal_newlines: bool = ...,
+        universal_newlines: Optional[bool] = ...,
         *,
         input: Optional[Union[str, bytes]] = ...,
         encoding: Optional[str] = ...,
@@ -373,7 +373,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     @overload
     def check_output(
         self,
-        universal_newlines: Literal[False],
+        universal_newlines: Literal[False, None],
         *,
         input: Optional[Union[str, bytes]] = ...,
         encoding: None = ...,
@@ -432,7 +432,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     @overload
     def run(
         self,
-        universal_newlines: bool = ...,
+        universal_newlines: Optional[bool] = ...,
         *,
         capture_output: bool = ...,
         check: bool = ...,
@@ -445,7 +445,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     @overload
     def run(
         self,
-        universal_newlines: bool = ...,
+        universal_newlines: Optional[bool] = ...,
         *,
         capture_output: bool = ...,
         check: bool = ...,
@@ -458,7 +458,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     @overload
     def run(
         self,
-        universal_newlines: bool = ...,
+        universal_newlines: Optional[bool] = ...,
         *,
         capture_output: bool = ...,
         check: bool = ...,
@@ -485,7 +485,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     @overload
     def run(
         self,
-        universal_newlines: Literal[False] = ...,
+        universal_newlines: Literal[False, None] = ...,
         *,
         capture_output: bool = ...,
         check: bool = ...,

--- a/src/libvcs/_internal/subprocess.py
+++ b/src/libvcs/_internal/subprocess.py
@@ -220,7 +220,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     def Popen(
         self,
         args: Optional[_CMD] = ...,
-        universal_newlines: Optional[bool] = ...,
+        universal_newlines: Optional[bool] = False,
         *,
         text: Optional[bool] = ...,
         encoding: str,
@@ -231,7 +231,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     def Popen(
         self,
         args: Optional[_CMD] = ...,
-        universal_newlines: Optional[bool] = ...,
+        universal_newlines: Optional[bool] = False,
         *,
         text: Optional[bool] = ...,
         encoding: Optional[str] = ...,
@@ -254,7 +254,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     def Popen(
         self,
         args: Optional[_CMD] = ...,
-        universal_newlines: Optional[bool] = ...,
+        universal_newlines: Optional[bool] = False,
         *,
         text: Literal[True],
         encoding: Optional[str] = ...,
@@ -265,11 +265,11 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     def Popen(
         self,
         args: Optional[_CMD] = ...,
-        universal_newlines: Literal[False, None] = ...,
+        universal_newlines: Literal[False, None] = False,
         *,
         text: Literal[None, False] = ...,
-        encoding: None = ...,
-        errors: None = ...,
+        encoding: None = None,
+        errors: None = None,
     ) -> subprocess.Popen[bytes]: ...
 
     def Popen(
@@ -377,8 +377,8 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         universal_newlines: Literal[False, None],
         *,
         input: Optional[Union[str, bytes]] = ...,
-        encoding: None = ...,
-        errors: None = ...,
+        encoding: None = None,
+        errors: None = None,
         text: Literal[None, False] = ...,
         **kwargs: Any,
     ) -> bytes: ...
@@ -490,8 +490,8 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         *,
         capture_output: bool = False,
         check: bool = False,
-        encoding: None = ...,
-        errors: None = ...,
+        encoding: None = None,
+        errors: None = None,
         input: Optional["ReadableBuffer"] = None,
         text: Literal[None, False] = ...,
     ) -> subprocess.CompletedProcess[bytes]: ...

--- a/src/libvcs/_internal/subprocess.py
+++ b/src/libvcs/_internal/subprocess.py
@@ -435,11 +435,11 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         self,
         universal_newlines: Optional[bool] = ...,
         *,
-        capture_output: bool = ...,
-        check: bool = ...,
+        capture_output: bool = False,
+        check: bool = False,
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
-        input: Optional["_InputString"] = ...,
+        input: Optional["_InputString"] = None,
         text: Literal[True],
     ) -> subprocess.CompletedProcess[str]: ...
 
@@ -448,11 +448,11 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         self,
         universal_newlines: Optional[bool] = ...,
         *,
-        capture_output: bool = ...,
-        check: bool = ...,
+        capture_output: bool = False,
+        check: bool = False,
         encoding: str,
         errors: Optional[str] = ...,
-        input: Optional["_InputString"] = ...,
+        input: Optional["_InputString"] = None,
         text: Optional[bool] = ...,
     ) -> subprocess.CompletedProcess[str]: ...
 
@@ -461,11 +461,11 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         self,
         universal_newlines: Optional[bool] = ...,
         *,
-        capture_output: bool = ...,
-        check: bool = ...,
+        capture_output: bool = False,
+        check: bool = False,
         encoding: Optional[str] = ...,
         errors: str,
-        input: Optional["_InputString"] = ...,
+        input: Optional["_InputString"] = None,
         text: Optional[bool] = ...,
     ) -> subprocess.CompletedProcess[str]: ...
 
@@ -475,11 +475,11 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         *,
         universal_newlines: Literal[True],
         # where the *real* keyword only args start
-        capture_output: bool = ...,
-        check: bool = ...,
+        capture_output: bool = False,
+        check: bool = False,
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
-        input: Optional["_InputString"] = ...,
+        input: Optional["_InputString"] = None,
         text: Optional[bool] = ...,
     ) -> subprocess.CompletedProcess[str]: ...
 
@@ -488,11 +488,11 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         self,
         universal_newlines: Literal[False, None] = ...,
         *,
-        capture_output: bool = ...,
-        check: bool = ...,
+        capture_output: bool = False,
+        check: bool = False,
         encoding: None = ...,
         errors: None = ...,
-        input: Optional["ReadableBuffer"] = ...,
+        input: Optional["ReadableBuffer"] = None,
         text: Literal[None, False] = ...,
     ) -> subprocess.CompletedProcess[bytes]: ...
 

--- a/src/libvcs/_internal/subprocess.py
+++ b/src/libvcs/_internal/subprocess.py
@@ -265,7 +265,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     def Popen(
         self,
         args: Optional[_CMD] = ...,
-        universal_newlines: Literal[False, None] = False,
+        universal_newlines: Optional[Literal[False]] = False,
         *,
         text: Literal[None, False] = ...,
         encoding: None = None,
@@ -374,7 +374,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     @overload
     def check_output(
         self,
-        universal_newlines: Literal[False, None],
+        universal_newlines: Optional[Literal[False]],
         *,
         input: Optional[Union[str, bytes]] = ...,
         encoding: None = None,
@@ -486,7 +486,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
     @overload
     def run(
         self,
-        universal_newlines: Literal[False, None] = ...,
+        universal_newlines: Optional[Literal[False]] = ...,
         *,
         capture_output: bool = False,
         check: bool = False,

--- a/src/libvcs/_internal/subprocess.py
+++ b/src/libvcs/_internal/subprocess.py
@@ -60,6 +60,7 @@ from libvcs._internal.types import StrOrBytesPath
 from .dataclasses import SkipDefaultFieldsReprMixin
 
 if TYPE_CHECKING:
+    from _typeshed import ReadableBuffer
     from typing_extensions import TypeAlias
 
 
@@ -79,7 +80,7 @@ else:
         Mapping[str, StrOrBytesPath],
     ]
 _FILE: "TypeAlias" = Union[None, int, IO[Any]]
-_TXT: "TypeAlias" = Union[bytes, str]
+_InputString: "TypeAlias" = Union["ReadableBuffer", str]
 #: Command
 _CMD: "TypeAlias" = Union[StrOrBytesPath, Sequence[StrOrBytesPath]]
 
@@ -438,7 +439,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         check: bool = ...,
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
-        input: Optional[str] = ...,
+        input: Optional["_InputString"] = ...,
         text: Literal[True],
     ) -> subprocess.CompletedProcess[str]: ...
 
@@ -451,7 +452,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         check: bool = ...,
         encoding: str,
         errors: Optional[str] = ...,
-        input: Optional[str] = ...,
+        input: Optional["_InputString"] = ...,
         text: Optional[bool] = ...,
     ) -> subprocess.CompletedProcess[str]: ...
 
@@ -464,7 +465,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         check: bool = ...,
         encoding: Optional[str] = ...,
         errors: str,
-        input: Optional[str] = ...,
+        input: Optional["_InputString"] = ...,
         text: Optional[bool] = ...,
     ) -> subprocess.CompletedProcess[str]: ...
 
@@ -478,7 +479,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         check: bool = ...,
         encoding: Optional[str] = ...,
         errors: Optional[str] = ...,
-        input: Optional[str] = ...,
+        input: Optional["_InputString"] = ...,
         text: Optional[bool] = ...,
     ) -> subprocess.CompletedProcess[str]: ...
 
@@ -491,7 +492,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         check: bool = ...,
         encoding: None = ...,
         errors: None = ...,
-        input: Optional[bytes] = ...,
+        input: Optional["ReadableBuffer"] = ...,
         text: Literal[None, False] = ...,
     ) -> subprocess.CompletedProcess[bytes]: ...
 
@@ -503,7 +504,7 @@ class SubprocessCommand(SkipDefaultFieldsReprMixin):
         check: bool = False,
         encoding: Optional[str] = None,
         errors: Optional[str] = None,
-        input: Optional[Union[str, bytes]] = None,
+        input: Optional[Union["_InputString", "ReadableBuffer"]] = None,
         text: Optional[bool] = None,
         timeout: Optional[float] = None,
         **kwargs: Any,


### PR DESCRIPTION
# Changes

## Backport typings

Backport typings since October 2022 onward: https://github.com/python/typeshed/commits/main/stdlib/subprocess.pyi

- `universal_newlines` being optional: https://github.com/python/typeshed/blob/1ce1c1ad17c6eb3c5cab19f8dac94af6a5894bca/stdlib/subprocess.pyi