### PR TITLE
Issue: `mercurial` / `svn` missing skips git tests

### DIFF
--- a/src/libvcs/pytest_plugin.py
+++ b/src/libvcs/pytest_plugin.py
@@ -103,16 +103,17 @@ namer = RandomStrSequence()
 
 def pytest_ignore_collect(collection_path: pathlib.Path, config: pytest.Config) -> bool:
     """Skip tests if VCS binaries are missing."""
-    if not shutil.which("svn") and any(
+    if any(
         needle in str(collection_path) for needle in ["svn", "subversion"]
-    ):
+    ) and not shutil.which("svn"):
         return True
-    if not shutil.which("git") and "git" in str(collection_path):
+    if "git" in str(collection_path) and not shutil.which("git"):
         return True
-    return bool(
-        not shutil.which("hg")
-        and any(needle in str(collection_path) for needle in ["hg", "mercurial"]),
-    )
+    if any(  # NOQA: SIM103
+        needle in str(collection_path) for needle in ["hg", "mercurial"]
+    ) and not shutil.which("hg"):
+        return True
+    return False
 
 
 @pytest.fixture(scope="session")

--- a/tests/sync/test_hg.py
+++ b/tests/sync/test_hg.py
@@ -22,14 +22,6 @@ if not shutil.which("hg"):
     pytestmark = pytest.mark.skip(reason="hg is not available")
 
 
-@pytest.fixture(autouse=True)
-def set_hgconfig(
-    set_hgconfig: pathlib.Path,
-) -> pathlib.Path:
-    """Set mercurial configuration."""
-    return set_hgconfig
-
-
 def test_hg_sync(
     tmp_path: pathlib.Path,
     projects_path: pathlib.Path,


### PR DESCRIPTION
# Problem

If `svn` (subversion) or `hg` (mercurial) isn't installed, fixtures for git-based tests won't run.

## Summary by Sourcery

Tests:
- Skip tests for Mercurial, Subversion, and Git if the corresponding VCS command is not available.