### PR TITLE
ci(tests) Verify runtime deps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,20 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Test runtime dependencies
+        # libvcs.pytest_plugin is intentionally excluded: it is a pytest plugin
+        # and imports pytest at module load. It is only meant to be used in test
+        # environments where pytest is already a dependency.
+        run: |
+          uv run --no-dev -p python${{ matrix.python-version }} -- python -c '
+          from libvcs import _internal, cmd, data, sync, url, exc, logger, __version__
+          from libvcs._internal import dataclasses, module_loading, query_list, run, shortcuts, subprocess, types
+          from libvcs.cmd import git as git_cmd, hg as hg_cmd, svn as svn_cmd
+          from libvcs.sync import git as git_sync, hg as hg_sync, svn as svn_sync
+          from libvcs.url import git as git_url, hg as hg_url, svn as svn_url
+          print("libvcs version:", __version__)
+          '
+
       - name: Install dependencies
         run: uv sync --all-extras --dev
 


### PR DESCRIPTION
## Changes
- Add runtime dependency check in CI using `uv run --no-dev`
- Run check before installing dev dependencies
- Print package version and basic functionality test results
- Document improvement in `CHANGES`

## Summary by Sourcery

Add a CI job to verify runtime dependencies before installing dev dependencies. This ensures that the package functions correctly with only its runtime dependencies installed.

CI:
- Add a CI job to verify runtime dependencies using `uv run --no-dev` before installing dev dependencies.
- The job prints the package version and runs a basic functionality test.