### PR TITLE
feat(pytest_plugin): Add XDG persistent cache and fixture optimization

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,22 @@ $ uv add libvcs --prerelease allow
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### pytest plugin
+
+#### pytest_plugin: Add XDG persistent cache for fixtures (#502)
+
+- Add XDG-based persistent cache at `~/.cache/libvcs/pytest/`
+- Add {class}`~libvcs.pytest_plugin.RepoFixtureResult` with cache hit/miss tracking
+- Add atomic initialization for pytest-xdist compatibility
+- Significantly faster test runs when cache is warm
+
+### Internal
+
+#### _internal: Add file locking module (#502)
+
+- Add {class}`~libvcs._internal.file_lock.FileLock` for cross-platform file locking
+- Add {func}`~libvcs._internal.file_lock.atomic_init` for race-free initialization
+
 ## libvcs 0.40.0 (2026-04-25)
 
 ### What's new

--- a/conftest.py
+++ b/conftest.py
@@ -10,14 +10,172 @@ https://docs.pytest.org/en/stable/deprecations.html
 
 from __future__ import annotations
 
+import dataclasses
+import time
 import typing as t
+from collections import defaultdict
 
 import pytest
 
 if t.TYPE_CHECKING:
     import pathlib
 
+    from _pytest.fixtures import FixtureDef, SubRequest
+    from _pytest.terminal import TerminalReporter
+
 pytest_plugins = ["pytester"]
+
+
+@dataclasses.dataclass
+class FixtureMetrics:
+    """Metrics collected during fixture execution."""
+
+    fixture_name: str
+    duration: float
+    cache_hit: bool | None = None  # None if not applicable (non-repo fixture)
+
+
+# Fixture profiling storage
+_fixture_timings: dict[str, list[float]] = defaultdict(list)
+_fixture_call_counts: dict[str, int] = defaultdict(int)
+_fixture_cache_hits: dict[str, int] = defaultdict(int)
+_fixture_cache_misses: dict[str, int] = defaultdict(int)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add fixture profiling options."""
+    group = parser.getgroup("libvcs", "libvcs fixture options")
+    group.addoption(
+        "--fixture-durations",
+        action="store",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Show N slowest fixture setup times (N=0 for all)",
+    )
+    group.addoption(
+        "--fixture-durations-min",
+        action="store",
+        type=float,
+        default=0.005,
+        metavar="SECONDS",
+        help="Minimum duration to show in fixture timing report (default: 0.005)",
+    )
+    group.addoption(
+        "--run-performance",
+        action="store_true",
+        default=False,
+        help="Run performance tests (marked with @pytest.mark.performance)",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    """Skip performance tests unless --run-performance is given."""
+    if config.getoption("--run-performance"):
+        # --run-performance given: run all tests
+        return
+
+    skip_performance = pytest.mark.skip(reason="need --run-performance option to run")
+    for item in items:
+        if "performance" in item.keywords:
+            item.add_marker(skip_performance)
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_fixture_setup(
+    fixturedef: FixtureDef[t.Any],
+    request: SubRequest,
+) -> t.Generator[None, t.Any, t.Any]:
+    """Wrap fixture setup to measure timing and track cache hits."""
+    start = time.perf_counter()
+    try:
+        result = yield
+        # Track cache hits for fixtures that support it (RepoFixtureResult)
+        if hasattr(result, "from_cache"):
+            fixture_name = fixturedef.argname
+            if result.from_cache:
+                _fixture_cache_hits[fixture_name] += 1
+            else:
+                _fixture_cache_misses[fixture_name] += 1
+        return result
+    finally:
+        duration = time.perf_counter() - start
+        fixture_name = fixturedef.argname
+        _fixture_timings[fixture_name].append(duration)
+        _fixture_call_counts[fixture_name] += 1
+
+
+def pytest_terminal_summary(
+    terminalreporter: TerminalReporter,
+    exitstatus: int,
+    config: pytest.Config,
+) -> None:
+    """Display fixture timing and cache statistics summary."""
+    durations_count = config.option.fixture_durations
+    durations_min = config.option.fixture_durations_min
+
+    # Skip if no timing requested (durations_count defaults to 0 meaning "off")
+    if durations_count == 0 and not config.option.verbose:
+        return
+
+    # Build summary data
+    fixture_stats: list[tuple[str, float, int, float]] = []
+    for name, times in _fixture_timings.items():
+        total_time = sum(times)
+        call_count = len(times)
+        avg_time = total_time / call_count if call_count > 0 else 0
+        fixture_stats.append((name, total_time, call_count, avg_time))
+
+    # Sort by total time descending
+    fixture_stats.sort(key=lambda x: x[1], reverse=True)
+
+    # Filter by minimum duration
+    fixture_stats = [s for s in fixture_stats if s[1] >= durations_min]
+
+    if not fixture_stats:
+        return
+
+    # Limit count if specified
+    if durations_count > 0:
+        fixture_stats = fixture_stats[:durations_count]
+
+    terminalreporter.write_sep("=", "fixture setup times")
+    terminalreporter.write_line("")
+    terminalreporter.write_line(
+        f"{'Fixture':<40} {'Total':>10} {'Calls':>8} {'Avg':>10}",
+    )
+    terminalreporter.write_line("-" * 70)
+
+    for name, total, calls, avg in fixture_stats:
+        terminalreporter.write_line(
+            f"{name:<40} {total:>9.3f}s {calls:>8} {avg:>9.3f}s",
+        )
+
+    # Display cache statistics if any repo fixtures were used
+    if _fixture_cache_hits or _fixture_cache_misses:
+        terminalreporter.write_line("")
+        terminalreporter.write_sep("=", "fixture cache statistics")
+        terminalreporter.write_line("")
+        terminalreporter.write_line(
+            f"{'Fixture':<40} {'Hits':>8} {'Misses':>8} {'Hit Rate':>10}",
+        )
+        terminalreporter.write_line("-" * 70)
+
+        # Combine hits and misses for all fixtures that have cache tracking
+        all_cache_fixtures = set(_fixture_cache_hits.keys()) | set(
+            _fixture_cache_misses.keys()
+        )
+        for name in sorted(all_cache_fixtures):
+            hits = _fixture_cache_hits.get(name, 0)
+            misses = _fixture_cache_misses.get(name, 0)
+            total = hits + misses
+            hit_rate = (hits / total * 100) if total > 0 else 0
+            terminalreporter.write_line(
+                f"{name:<40} {hits:>8} {misses:>8} {hit_rate:>9.1f}%",
+            )
 
 
 @pytest.fixture(autouse=True)

--- a/docs/internals/file_lock.md
+++ b/docs/internals/file_lock.md
@@ -1,0 +1,79 @@
+# FileLock - `libvcs._internal.file_lock`
+
+Typed, asyncio-friendly file locking based on [filelock](https://github.com/tox-dev/filelock) patterns.
+
+## Overview
+
+This module provides portable file-based locking using the **SoftFileLock** pattern
+(`os.O_CREAT | os.O_EXCL`) for atomic lock acquisition. It supports both synchronous
+and asynchronous contexts.
+
+### Key Features
+
+- **Atomic acquisition**: Uses `os.O_CREAT | os.O_EXCL` for race-free lock creation
+- **Reentrant locking**: Same thread can acquire lock multiple times
+- **Stale lock detection**: Auto-removes locks older than configurable timeout (default 5min)
+- **Async support**: {class}`~libvcs._internal.file_lock.AsyncFileLock` with `asyncio.sleep` polling
+- **Two-file pattern**: Lock file (temporary) + marker file (permanent)
+- **PID tracking**: Writes PID to lock file for debugging
+
+## Quick Start
+
+### Synchronous Usage
+
+```python
+from libvcs._internal.file_lock import FileLock
+
+# Context manager (recommended)
+with FileLock("/tmp/my.lock"):
+    # Critical section - only one process at a time
+    pass
+
+# Explicit acquire/release
+lock = FileLock("/tmp/my.lock")
+lock.acquire()
+try:
+    # Critical section
+    pass
+finally:
+    lock.release()
+```
+
+### Asynchronous Usage
+
+```python
+import asyncio
+from libvcs._internal.file_lock import AsyncFileLock
+
+async def main():
+    async with AsyncFileLock("/tmp/my.lock"):
+        # Async critical section
+        pass
+
+asyncio.run(main())
+```
+
+### Atomic Initialization
+
+The {func}`~libvcs._internal.file_lock.atomic_init` function implements the **two-file pattern**
+for coordinating one-time initialization across multiple processes:
+
+```python
+from libvcs._internal.file_lock import atomic_init
+
+def expensive_init():
+    # One-time setup (e.g., clone repo, build cache)
+    pass
+
+# First call does initialization, subsequent calls skip
+did_init = atomic_init("/path/to/resource", expensive_init)
+```
+
+## API Reference
+
+```{eval-rst}
+.. automodule:: libvcs._internal.file_lock
+   :members:
+   :undoc-members:
+   :show-inheritance:
+```

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -61,6 +61,7 @@ Convenience functions for common operations.
 exc
 types
 dataclasses
+file_lock
 query_list
 run
 subprocess

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,9 @@ dev = [
   # Testing
   "gp-libs",
   "pytest",
-  "pytest-rerunfailures",
+  "pytest-asyncio",
   "pytest-mock",
+  "pytest-rerunfailures",
   "pytest-watcher",
   # Coverage
   "codecov",
@@ -94,8 +95,9 @@ docs = [
 testing = [
   "gp-libs",
   "pytest",
-  "pytest-rerunfailures",
+  "pytest-asyncio",
   "pytest-mock",
+  "pytest-rerunfailures",
   "pytest-watcher",
 ]
 coverage =[
@@ -245,6 +247,10 @@ testpaths = [
 ]
 filterwarnings = [
   "ignore:The frontend.Option(Parser)? class.*:DeprecationWarning::",
+]
+markers = [
+  "performance: marks tests as performance tests (deselect with '-m \"not performance\"')",
+  "benchmark: marks tests as benchmark tests for comparing implementation methods",
 ]
 
 [tool.pytest-watcher]

--- a/src/libvcs/_internal/file_lock.py
+++ b/src/libvcs/_internal/file_lock.py
@@ -1,0 +1,1025 @@
+"""Typed, asyncio-friendly file locking based on filelock patterns.
+
+This module provides atomic file-based locking with support for both synchronous
+and asynchronous contexts. It uses the SoftFileLock pattern (``os.O_CREAT | os.O_EXCL``)
+for portable, atomic lock acquisition.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+
+Design Principles
+-----------------
+1. **Atomic acquisition**: Uses ``os.O_CREAT | os.O_EXCL`` for race-free lock creation
+2. **Reentrant locking**: Same thread can acquire lock multiple times
+3. **Stale lock detection**: Auto-removes locks older than configurable timeout
+4. **Async support**: :class:`AsyncFileLock` wraps sync lock with ``asyncio.sleep``
+5. **PID tracking**: Writes PID to lock file for debugging
+6. **Two-file pattern**: Lock file (temporary) + marker file (permanent)
+
+Examples
+--------
+Basic synchronous usage:
+
+>>> import tempfile
+>>> import pathlib
+>>> with tempfile.TemporaryDirectory() as tmpdir:
+...     lock_path = pathlib.Path(tmpdir) / "my.lock"
+...     lock = FileLock(lock_path)
+...     with lock:
+...         # Critical section - only one process at a time
+...         pass
+...     lock.is_locked
+False
+
+Async usage:
+
+>>> async def example():
+...     import tempfile
+...     import pathlib
+...     with tempfile.TemporaryDirectory() as tmpdir:
+...         lock_path = pathlib.Path(tmpdir) / "my.lock"
+...         async with AsyncFileLock(lock_path):
+...             # Async critical section
+...             pass
+...         return "done"
+>>> asyncio.run(example())
+'done'
+
+Two-file atomic initialization pattern:
+
+>>> def do_expensive_init():
+...     pass  # Expensive one-time setup
+>>> with tempfile.TemporaryDirectory() as tmpdir:
+...     path = pathlib.Path(tmpdir) / "resource"
+...     path.mkdir()
+...     result = atomic_init(path, do_expensive_init)
+...     result  # True if we did init, False if another process did
+True
+
+See Also
+--------
+- filelock: The library that inspired this implementation
+- pytest's make_numbered_dir_with_cleanup: Similar atomic init pattern
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import dataclasses
+import os
+import pathlib
+import shutil
+import time
+import typing as t
+from types import TracebackType
+
+if t.TYPE_CHECKING:
+    from typing_extensions import Self
+
+__all__ = [
+    "AcquireReturnProxy",
+    "AsyncAcquireReturnProxy",
+    "AsyncFileLock",
+    "FileLock",
+    "FileLockContext",
+    "FileLockError",
+    "FileLockStale",
+    "FileLockTimeout",
+    "async_atomic_init",
+    "atomic_init",
+]
+
+
+# =============================================================================
+# Exceptions
+# =============================================================================
+
+
+class FileLockError(Exception):
+    """Base exception for file lock errors.
+
+    All file lock-related exceptions inherit from this class, making it easy
+    to catch any lock-related error with a single except clause.
+
+    Examples
+    --------
+    >>> try:
+    ...     raise FileLockError("Lock failed")
+    ... except FileLockError as e:
+    ...     str(e)
+    'Lock failed'
+    """
+
+
+class FileLockTimeout(FileLockError, TimeoutError):
+    """Raised when lock acquisition times out.
+
+    This exception inherits from both :class:`FileLockError` and
+    :class:`TimeoutError`, allowing it to be caught by either.
+
+    Parameters
+    ----------
+    lock_file : str
+        Path to the lock file that could not be acquired.
+    timeout : float
+        Timeout value in seconds that was exceeded.
+
+    Examples
+    --------
+    >>> exc = FileLockTimeout("/tmp/my.lock", 30.0)
+    >>> str(exc)
+    'Timeout (30.0s) waiting for lock: /tmp/my.lock'
+    >>> exc.lock_file
+    '/tmp/my.lock'
+    >>> exc.timeout
+    30.0
+    """
+
+    def __init__(self, lock_file: str, timeout: float) -> None:
+        #: Path to the lock file
+        self.lock_file = lock_file
+        #: Timeout in seconds
+        self.timeout = timeout
+        super().__init__(f"Timeout ({timeout}s) waiting for lock: {lock_file}")
+
+    def __reduce__(self) -> tuple[type[FileLockTimeout], tuple[str, float]]:
+        """Support pickling for multiprocessing."""
+        return self.__class__, (self.lock_file, self.timeout)
+
+
+class FileLockStale(FileLockError):
+    """Informational exception for stale lock detection.
+
+    This exception is raised when a stale lock is detected but cannot be
+    removed. It's primarily informational and can be caught to log warnings.
+
+    Parameters
+    ----------
+    lock_file : str
+        Path to the stale lock file.
+    age_seconds : float
+        Age of the lock file in seconds.
+
+    Examples
+    --------
+    >>> exc = FileLockStale("/tmp/my.lock", 3600.0)
+    >>> str(exc)
+    'Stale lock (3600.0s old): /tmp/my.lock'
+    """
+
+    def __init__(self, lock_file: str, age_seconds: float) -> None:
+        #: Path to the stale lock file
+        self.lock_file = lock_file
+        #: Age in seconds
+        self.age_seconds = age_seconds
+        super().__init__(f"Stale lock ({age_seconds}s old): {lock_file}")
+
+    def __reduce__(self) -> tuple[type[FileLockStale], tuple[str, float]]:
+        """Support pickling for multiprocessing."""
+        return self.__class__, (self.lock_file, self.age_seconds)
+
+
+# =============================================================================
+# Context Dataclass
+# =============================================================================
+
+
+@dataclasses.dataclass
+class FileLockContext:
+    """Internal state container for :class:`FileLock`.
+
+    This dataclass holds all the configuration and runtime state for a file
+    lock. It's separated from the lock class to allow easier testing and
+    to support potential future features like lock serialization.
+
+    Parameters
+    ----------
+    lock_file : str
+        Absolute path to the lock file.
+    timeout : float, default=-1.0
+        Timeout for lock acquisition. -1 means wait forever.
+    poll_interval : float, default=0.05
+        Interval between acquisition attempts in seconds.
+    stale_timeout : float, default=300.0
+        Age in seconds after which a lock is considered stale.
+    mode : int, default=0o644
+        File permission mode for the lock file.
+    lock_file_fd : int or None
+        File descriptor when lock is held, None otherwise.
+    lock_counter : int, default=0
+        Reentrant lock counter (number of times acquired).
+
+    Examples
+    --------
+    >>> ctx = FileLockContext("/tmp/my.lock")
+    >>> ctx.is_locked
+    False
+    >>> ctx.lock_counter
+    0
+    """
+
+    lock_file: str
+    timeout: float = -1.0
+    poll_interval: float = 0.05
+    stale_timeout: float = 300.0
+    mode: int = 0o644
+    lock_file_fd: int | None = dataclasses.field(default=None, repr=False)
+    lock_counter: int = 0
+
+    @property
+    def is_locked(self) -> bool:
+        """Check if the lock is currently held.
+
+        Returns
+        -------
+        bool
+            True if the lock is held, False otherwise.
+        """
+        return self.lock_file_fd is not None
+
+
+# =============================================================================
+# Return Proxies
+# =============================================================================
+
+
+class AcquireReturnProxy:
+    """Context manager proxy returned by :meth:`FileLock.acquire`.
+
+    This proxy allows the acquire/release pattern to be used with context
+    managers while still supporting explicit acquire() calls.
+
+    Parameters
+    ----------
+    lock : FileLock
+        The lock instance this proxy wraps.
+
+    Examples
+    --------
+    >>> import tempfile
+    >>> import pathlib
+    >>> with tempfile.TemporaryDirectory() as tmpdir:
+    ...     lock_path = pathlib.Path(tmpdir) / "my.lock"
+    ...     lock = FileLock(lock_path)
+    ...     with lock.acquire():  # Returns AcquireReturnProxy
+    ...         pass  # Lock is held
+    ...     lock.is_locked
+    False
+    """
+
+    def __init__(self, lock: FileLock) -> None:
+        self._lock = lock
+
+    def __enter__(self) -> FileLock:
+        """Enter context manager, returning the lock."""
+        return self._lock
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context manager, releasing the lock."""
+        self._lock.release()
+
+
+class AsyncAcquireReturnProxy:
+    """Async context manager proxy returned by :meth:`AsyncFileLock.acquire`.
+
+    Parameters
+    ----------
+    lock : AsyncFileLock
+        The async lock instance this proxy wraps.
+
+    Examples
+    --------
+    >>> async def example():
+    ...     import tempfile
+    ...     import pathlib
+    ...     with tempfile.TemporaryDirectory() as tmpdir:
+    ...         lock_path = pathlib.Path(tmpdir) / "my.lock"
+    ...         lock = AsyncFileLock(lock_path)
+    ...         proxy = await lock.acquire()
+    ...         async with proxy:
+    ...             pass  # Lock is held
+    ...         return lock.is_locked
+    >>> asyncio.run(example())
+    False
+    """
+
+    def __init__(self, lock: AsyncFileLock) -> None:
+        self._lock = lock
+
+    async def __aenter__(self) -> AsyncFileLock:
+        """Enter async context manager, returning the lock."""
+        return self._lock
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit async context manager, releasing the lock."""
+        await self._lock.release()
+
+
+# =============================================================================
+# FileLock (Synchronous)
+# =============================================================================
+
+
+class FileLock(contextlib.ContextDecorator):
+    """Portable file-based lock using atomic file creation.
+
+    This lock uses the SoftFileLock pattern where lock acquisition is
+    achieved through atomic file creation with ``os.O_CREAT | os.O_EXCL``.
+    This is portable across platforms and doesn't require OS-level locking.
+
+    The lock is reentrant: the same thread can acquire it multiple times,
+    and must release it the same number of times.
+
+    Parameters
+    ----------
+    lock_file : str or PathLike
+        Path to the lock file. Parent directory must exist.
+    timeout : float, default=-1.0
+        Maximum time to wait for lock acquisition in seconds.
+        Use -1 for infinite wait, 0 for non-blocking.
+    poll_interval : float, default=0.05
+        Time between acquisition attempts in seconds.
+    stale_timeout : float, default=300.0
+        Locks older than this (in seconds) are considered stale and
+        may be removed automatically. Default is 5 minutes.
+    mode : int, default=0o644
+        File permission mode for the lock file.
+
+    Attributes
+    ----------
+    lock_file : str
+        Path to the lock file.
+    is_locked : bool
+        Whether the lock is currently held.
+
+    Examples
+    --------
+    Context manager usage:
+
+    >>> import tempfile
+    >>> import pathlib
+    >>> with tempfile.TemporaryDirectory() as tmpdir:
+    ...     lock_path = pathlib.Path(tmpdir) / "my.lock"
+    ...     with FileLock(lock_path):
+    ...         # Critical section
+    ...         pass
+
+    Explicit acquire/release:
+
+    >>> with tempfile.TemporaryDirectory() as tmpdir:
+    ...     lock_path = pathlib.Path(tmpdir) / "my.lock"
+    ...     lock = FileLock(lock_path)
+    ...     lock.acquire()  # doctest: +ELLIPSIS
+    ...     try:
+    ...         pass  # Critical section
+    ...     finally:
+    ...         lock.release()
+    <...AcquireReturnProxy object at ...>
+
+    Non-blocking try-acquire:
+
+    >>> with tempfile.TemporaryDirectory() as tmpdir:
+    ...     lock_path = pathlib.Path(tmpdir) / "my.lock"
+    ...     lock = FileLock(lock_path, timeout=0)
+    ...     try:
+    ...         with lock:
+    ...             pass  # Got the lock
+    ...     except FileLockTimeout:
+    ...         pass  # Lock was held by another process
+
+    See Also
+    --------
+    AsyncFileLock : Async version of this lock.
+    """
+
+    def __init__(
+        self,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1.0,
+        poll_interval: float = 0.05,
+        stale_timeout: float = 300.0,
+        mode: int = 0o644,
+    ) -> None:
+        self._context = FileLockContext(
+            lock_file=os.fspath(lock_file),
+            timeout=timeout,
+            poll_interval=poll_interval,
+            stale_timeout=stale_timeout,
+            mode=mode,
+        )
+
+    @property
+    def lock_file(self) -> str:
+        """Return the path to the lock file."""
+        return self._context.lock_file
+
+    @property
+    def is_locked(self) -> bool:
+        """Check if the lock is currently held by this instance."""
+        return self._context.is_locked
+
+    @property
+    def lock_counter(self) -> int:
+        """Return the number of times this lock has been acquired."""
+        return self._context.lock_counter
+
+    def _acquire(self) -> None:
+        """Low-level lock acquisition using os.O_CREAT | os.O_EXCL.
+
+        Raises
+        ------
+        FileExistsError
+            If the lock file already exists (lock is held).
+        """
+        fd = os.open(
+            self._context.lock_file,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            self._context.mode,
+        )
+        self._context.lock_file_fd = fd
+        # Write PID for debugging stale locks
+        os.write(fd, str(os.getpid()).encode())
+
+    def _release(self) -> None:
+        """Low-level lock release: close fd and remove file."""
+        fd = self._context.lock_file_fd
+        if fd is not None:
+            os.close(fd)
+            self._context.lock_file_fd = None
+            pathlib.Path(self._context.lock_file).unlink(missing_ok=True)
+
+    def _is_stale(self) -> bool:
+        """Check if the existing lock file is stale.
+
+        Returns
+        -------
+        bool
+            True if the lock is stale (older than stale_timeout).
+        """
+        try:
+            mtime = pathlib.Path(self._context.lock_file).stat().st_mtime
+            age = time.time() - mtime
+        except OSError:
+            return True
+        else:
+            return age > self._context.stale_timeout
+
+    def _remove_stale_lock(self) -> bool:
+        """Try to remove a stale lock file.
+
+        Returns
+        -------
+        bool
+            True if the stale lock was removed, False otherwise.
+        """
+        if self._is_stale():
+            try:
+                pathlib.Path(self._context.lock_file).unlink()
+            except OSError:
+                pass
+            else:
+                return True
+        return False
+
+    def acquire(
+        self,
+        timeout: float | None = None,
+        poll_interval: float | None = None,
+        *,
+        blocking: bool = True,
+    ) -> AcquireReturnProxy:
+        """Acquire the file lock.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            Override the default timeout for this acquisition.
+        poll_interval : float, optional
+            Override the default poll interval for this acquisition.
+        blocking : bool, default=True
+            If False, equivalent to timeout=0.
+
+        Returns
+        -------
+        AcquireReturnProxy
+            A context manager that releases the lock on exit.
+
+        Raises
+        ------
+        FileLockTimeout
+            If the lock cannot be acquired within the timeout.
+
+        Examples
+        --------
+        >>> import tempfile
+        >>> import pathlib
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     lock_path = pathlib.Path(tmpdir) / "my.lock"
+        ...     lock = FileLock(lock_path)
+        ...     with lock.acquire(timeout=5.0):
+        ...         pass  # Lock held
+        """
+        # Handle non-blocking mode
+        if not blocking:
+            timeout = 0
+
+        # Use instance defaults if not overridden
+        if timeout is None:
+            timeout = self._context.timeout
+        if poll_interval is None:
+            poll_interval = self._context.poll_interval
+
+        # Reentrant: if already locked, just increment counter
+        if self._context.lock_file_fd is not None:
+            self._context.lock_counter += 1
+            return AcquireReturnProxy(self)
+
+        start_time = time.perf_counter()
+
+        while True:
+            try:
+                self._acquire()
+                self._context.lock_counter = 1
+                return AcquireReturnProxy(self)
+            except FileExistsError:
+                pass
+
+            # Check for stale lock
+            if self._remove_stale_lock():
+                continue  # Retry immediately after removing stale lock
+
+            # Check timeout
+            elapsed = time.perf_counter() - start_time
+            if timeout >= 0 and elapsed >= timeout:
+                raise FileLockTimeout(self._context.lock_file, timeout)
+
+            # Wait before retrying
+            time.sleep(poll_interval)
+
+    def release(self, force: bool = False) -> None:
+        """Release the file lock.
+
+        Parameters
+        ----------
+        force : bool, default=False
+            If True, release the lock even if counter > 1.
+
+        Notes
+        -----
+        For reentrant locks, each acquire() must be matched by a release().
+        Use force=True to release regardless of the counter.
+
+        Examples
+        --------
+        >>> import tempfile
+        >>> import pathlib
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     lock_path = pathlib.Path(tmpdir) / "my.lock"
+        ...     lock = FileLock(lock_path)
+        ...     lock.acquire()  # doctest: +ELLIPSIS
+        ...     lock.lock_counter
+        ...     lock.release()
+        ...     lock.is_locked
+        <...AcquireReturnProxy object at ...>
+        1
+        False
+        """
+        if self._context.lock_file_fd is None:
+            return
+
+        if force:
+            self._context.lock_counter = 0
+            self._release()
+        else:
+            self._context.lock_counter -= 1
+            if self._context.lock_counter <= 0:
+                self._context.lock_counter = 0
+                self._release()
+
+    def __enter__(self) -> Self:
+        """Enter context manager, acquiring the lock."""
+        self.acquire()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context manager, releasing the lock."""
+        self.release()
+
+    def __repr__(self) -> str:
+        """Return a string representation of the lock."""
+        state = "locked" if self.is_locked else "unlocked"
+        return f"<FileLock({self.lock_file!r}, {state})>"
+
+
+# =============================================================================
+# AsyncFileLock
+# =============================================================================
+
+
+class AsyncFileLock:
+    """Async file lock wrapping :class:`FileLock` with async polling.
+
+    This class provides an async interface to the underlying :class:`FileLock`,
+    using ``asyncio.sleep`` instead of blocking ``time.sleep`` during
+    acquisition polling. This allows other coroutines to run while waiting
+    for the lock.
+
+    Parameters
+    ----------
+    lock_file : str or PathLike
+        Path to the lock file. Parent directory must exist.
+    timeout : float, default=-1.0
+        Maximum time to wait for lock acquisition in seconds.
+        Use -1 for infinite wait, 0 for non-blocking.
+    poll_interval : float, default=0.05
+        Time between acquisition attempts in seconds.
+    stale_timeout : float, default=300.0
+        Locks older than this (in seconds) are considered stale.
+    mode : int, default=0o644
+        File permission mode for the lock file.
+
+    Examples
+    --------
+    Async context manager:
+
+    >>> async def example():
+    ...     import tempfile
+    ...     import pathlib
+    ...     with tempfile.TemporaryDirectory() as tmpdir:
+    ...         lock_path = pathlib.Path(tmpdir) / "my.lock"
+    ...         async with AsyncFileLock(lock_path) as lock:
+    ...             return lock.is_locked
+    >>> asyncio.run(example())
+    True
+
+    Explicit acquire/release:
+
+    >>> async def example2():
+    ...     import tempfile
+    ...     import pathlib
+    ...     with tempfile.TemporaryDirectory() as tmpdir:
+    ...         lock_path = pathlib.Path(tmpdir) / "my.lock"
+    ...         lock = AsyncFileLock(lock_path)
+    ...         await lock.acquire()
+    ...         try:
+    ...             return lock.is_locked
+    ...         finally:
+    ...             await lock.release()
+    >>> asyncio.run(example2())
+    True
+
+    See Also
+    --------
+    FileLock : Synchronous version.
+    """
+
+    def __init__(
+        self,
+        lock_file: str | os.PathLike[str],
+        timeout: float = -1.0,
+        poll_interval: float = 0.05,
+        stale_timeout: float = 300.0,
+        mode: int = 0o644,
+    ) -> None:
+        self._sync_lock = FileLock(
+            lock_file=lock_file,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            stale_timeout=stale_timeout,
+            mode=mode,
+        )
+
+    @property
+    def lock_file(self) -> str:
+        """Return the path to the lock file."""
+        return self._sync_lock.lock_file
+
+    @property
+    def is_locked(self) -> bool:
+        """Check if the lock is currently held by this instance."""
+        return self._sync_lock.is_locked
+
+    @property
+    def lock_counter(self) -> int:
+        """Return the number of times this lock has been acquired."""
+        return self._sync_lock.lock_counter
+
+    async def acquire(
+        self,
+        timeout: float | None = None,
+        poll_interval: float | None = None,
+        *,
+        blocking: bool = True,
+    ) -> AsyncAcquireReturnProxy:
+        """Acquire the file lock asynchronously.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            Override the default timeout for this acquisition.
+        poll_interval : float, optional
+            Override the default poll interval for this acquisition.
+        blocking : bool, default=True
+            If False, equivalent to timeout=0.
+
+        Returns
+        -------
+        AsyncAcquireReturnProxy
+            An async context manager that releases the lock on exit.
+
+        Raises
+        ------
+        FileLockTimeout
+            If the lock cannot be acquired within the timeout.
+        """
+        if not blocking:
+            timeout = 0
+
+        ctx = self._sync_lock._context
+        if timeout is None:
+            timeout = ctx.timeout
+        if poll_interval is None:
+            poll_interval = ctx.poll_interval
+
+        # Reentrant
+        if ctx.lock_file_fd is not None:
+            ctx.lock_counter += 1
+            return AsyncAcquireReturnProxy(self)
+
+        start_time = time.perf_counter()
+
+        while True:
+            try:
+                self._sync_lock._acquire()
+                ctx.lock_counter = 1
+                return AsyncAcquireReturnProxy(self)
+            except FileExistsError:
+                pass
+
+            # Check for stale lock
+            if self._sync_lock._remove_stale_lock():
+                continue
+
+            # Check timeout
+            elapsed = time.perf_counter() - start_time
+            if timeout >= 0 and elapsed >= timeout:
+                raise FileLockTimeout(ctx.lock_file, timeout)
+
+            # Async sleep to allow other coroutines to run
+            await asyncio.sleep(poll_interval)
+
+    async def release(self, force: bool = False) -> None:
+        """Release the file lock.
+
+        Parameters
+        ----------
+        force : bool, default=False
+            If True, release the lock even if counter > 1.
+        """
+        self._sync_lock.release(force=force)
+
+    async def __aenter__(self) -> Self:
+        """Enter async context manager, acquiring the lock."""
+        await self.acquire()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit async context manager, releasing the lock."""
+        await self.release()
+
+    def __repr__(self) -> str:
+        """Return a string representation of the lock."""
+        state = "locked" if self.is_locked else "unlocked"
+        return f"<AsyncFileLock({self.lock_file!r}, {state})>"
+
+
+# =============================================================================
+# Convenience Functions
+# =============================================================================
+
+
+def atomic_init(
+    path: str | os.PathLike[str],
+    init_fn: t.Callable[[], None],
+    marker_name: str = ".initialized",
+    timeout: float = 60.0,
+    poll_interval: float = 0.05,
+    stale_timeout: float = 300.0,
+) -> bool:
+    """Atomically initialize a resource using the two-file pattern.
+
+    This function coordinates one-time initialization across multiple processes
+    using a combination of a lock file and a marker file:
+
+    - **Lock file**: Temporary file held during initialization, deleted after.
+    - **Marker file**: Permanent file indicating initialization is complete.
+
+    This pattern is useful for expensive one-time setup like cloning
+    repositories, building caches, or creating database schemas.
+
+    Parameters
+    ----------
+    path : str or PathLike
+        Directory where the marker file will be created.
+    init_fn : callable
+        Function to call for initialization. Called only if not already
+        initialized. Must be idempotent in case of partial failure.
+    marker_name : str, default=".initialized"
+        Name of the marker file within ``path``.
+    timeout : float, default=60.0
+        Maximum time to wait for another process to finish initialization.
+    poll_interval : float, default=0.05
+        Time between lock acquisition attempts.
+    stale_timeout : float, default=300.0
+        Time after which an orphaned lock is considered stale.
+
+    Returns
+    -------
+    bool
+        True if this call performed initialization, False if another
+        process did or had already done it.
+
+    Raises
+    ------
+    FileLockTimeout
+        If initialization by another process doesn't complete within timeout.
+
+    Examples
+    --------
+    >>> import tempfile
+    >>> import pathlib
+    >>> def expensive_init():
+    ...     pass  # One-time setup
+    >>> with tempfile.TemporaryDirectory() as tmpdir:
+    ...     resource_path = pathlib.Path(tmpdir) / "myresource"
+    ...     resource_path.mkdir()
+    ...     # First call does initialization
+    ...     first = atomic_init(resource_path, expensive_init)
+    ...     # Second call sees marker and skips
+    ...     second = atomic_init(resource_path, expensive_init)
+    ...     first, second
+    (True, False)
+
+    With cleanup on partial failure:
+
+    >>> def init_with_cleanup():
+    ...     import pathlib
+    ...     import tempfile
+    ...     with tempfile.TemporaryDirectory() as tmpdir:
+    ...         path = pathlib.Path(tmpdir) / "repo"
+    ...         path.mkdir()
+    ...         def do_init():
+    ...             (path / "data.txt").write_text("hello")
+    ...         atomic_init(path, do_init)
+    ...         return (path / "data.txt").exists()
+    >>> init_with_cleanup()
+    True
+
+    See Also
+    --------
+    async_atomic_init : Async version of this function.
+    """
+    path = pathlib.Path(path)
+    marker = path / marker_name
+    lock_path = path.parent / f".{path.name}.lock"
+
+    # Fast path: already initialized
+    if marker.exists():
+        return False
+
+    lock = FileLock(
+        lock_path,
+        timeout=timeout,
+        poll_interval=poll_interval,
+        stale_timeout=stale_timeout,
+    )
+
+    with lock:
+        # Double-check after acquiring lock
+        if marker.exists():
+            return False
+
+        # Clean partial state if needed
+        if path.exists() and not marker.exists():
+            shutil.rmtree(path, ignore_errors=True)
+            path.mkdir(parents=True, exist_ok=True)
+
+        # Perform initialization
+        init_fn()
+
+        # Mark as complete
+        marker.touch()
+        return True
+
+
+async def async_atomic_init(
+    path: str | os.PathLike[str],
+    init_fn: t.Callable[[], None] | t.Callable[[], t.Coroutine[t.Any, t.Any, None]],
+    marker_name: str = ".initialized",
+    timeout: float = 60.0,
+    poll_interval: float = 0.05,
+    stale_timeout: float = 300.0,
+) -> bool:
+    """Atomically initialize a resource asynchronously.
+
+    Async version of :func:`atomic_init`. Supports both sync and async
+    ``init_fn`` callables.
+
+    Parameters
+    ----------
+    path : str or PathLike
+        Directory where the marker file will be created.
+    init_fn : callable
+        Sync or async function to call for initialization.
+    marker_name : str, default=".initialized"
+        Name of the marker file within ``path``.
+    timeout : float, default=60.0
+        Maximum time to wait for another process to finish initialization.
+    poll_interval : float, default=0.05
+        Time between lock acquisition attempts.
+    stale_timeout : float, default=300.0
+        Time after which an orphaned lock is considered stale.
+
+    Returns
+    -------
+    bool
+        True if this call performed initialization, False otherwise.
+
+    Raises
+    ------
+    FileLockTimeout
+        If initialization by another process doesn't complete within timeout.
+
+    Examples
+    --------
+    >>> async def example():
+    ...     import tempfile
+    ...     import pathlib
+    ...     async def async_init():
+    ...         await asyncio.sleep(0)  # Simulate async work
+    ...     with tempfile.TemporaryDirectory() as tmpdir:
+    ...         path = pathlib.Path(tmpdir) / "resource"
+    ...         path.mkdir()
+    ...         result = await async_atomic_init(path, async_init)
+    ...         return result
+    >>> asyncio.run(example())
+    True
+
+    See Also
+    --------
+    atomic_init : Synchronous version.
+    """
+    import inspect
+
+    path = pathlib.Path(path)
+    marker = path / marker_name
+    lock_path = path.parent / f".{path.name}.lock"
+
+    # Fast path
+    if marker.exists():
+        return False
+
+    lock = AsyncFileLock(
+        lock_path,
+        timeout=timeout,
+        poll_interval=poll_interval,
+        stale_timeout=stale_timeout,
+    )
+
+    async with lock:
+        if marker.exists():
+            return False
+
+        if path.exists() and not marker.exists():
+            shutil.rmtree(path, ignore_errors=True)
+            path.mkdir(parents=True, exist_ok=True)
+
+        # Handle both sync and async init functions
+        result = init_fn()
+        if inspect.iscoroutine(result):
+            await result
+
+        marker.touch()
+        return True

--- a/src/libvcs/pytest_plugin.py
+++ b/src/libvcs/pytest_plugin.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
+import dataclasses
 import functools
 import getpass
+import hashlib
+import os
 import pathlib
 import random
 import shutil
+import subprocess
 import textwrap
+import time
 import typing as t
+from importlib.metadata import version as get_package_version
 
 import pytest
 
 from libvcs import exc
+from libvcs._internal.file_lock import atomic_init
 from libvcs._internal.run import _ENV, run
 from libvcs.sync.git import GitRemote, GitSync
 from libvcs.sync.hg import HgSync
@@ -41,6 +48,156 @@ skip_if_hg_missing = pytest.mark.skipif(
     not shutil.which("hg"),
     reason="hg is not available",
 )
+
+
+# =============================================================================
+# Repo Fixture Result Dataclass
+# =============================================================================
+
+RepoT = t.TypeVar("RepoT")
+
+
+@dataclasses.dataclass
+class RepoFixtureResult(t.Generic[RepoT]):
+    """Result from repo fixture with metadata.
+
+    This dataclass wraps the repository instance with additional metadata
+    about the fixture setup, including timing and cache information.
+
+    Attributes
+    ----------
+    repo : RepoT
+        The actual repository instance (GitSync, HgSync, SvnSync, or async variants)
+    path : pathlib.Path
+        Path to the repository working directory
+    remote_url : str
+        URL of the remote repository (file:// based)
+    master_copy_path : pathlib.Path
+        Path to the cached master copy
+    created_at : float
+        Time when the fixture was created (perf_counter)
+    from_cache : bool
+        True if the repo was copied from an existing master cache
+
+    Examples
+    --------
+    >>> def test_git_operations(git_repo):
+    ...     # Direct access to repo methods via __getattr__
+    ...     revision = git_repo.get_revision()
+    ...
+    ...     # Access metadata
+    ...     assert git_repo.from_cache  # True if using cached copy
+    ...     print(f"Setup took: {time.perf_counter() - git_repo.created_at:.3f}s")
+    ...
+    ...     # Access the underlying repo directly
+    ...     assert isinstance(git_repo.repo, GitSync)
+    """
+
+    repo: RepoT
+    path: pathlib.Path
+    remote_url: str
+    master_copy_path: pathlib.Path
+    created_at: float
+    from_cache: bool
+
+    def __getattr__(self, name: str) -> t.Any:
+        """Delegate attribute access to the underlying repo for backwards compat."""
+        return getattr(self.repo, name)
+
+
+# =============================================================================
+# XDG Persistent Cache Infrastructure
+# =============================================================================
+
+
+def get_xdg_cache_dir() -> pathlib.Path:
+    """Get XDG cache directory for libvcs tests.
+
+    Uses XDG_CACHE_HOME if set, otherwise defaults to ~/.cache.
+    """
+    xdg_cache = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache:
+        return pathlib.Path(xdg_cache) / "libvcs-test"
+    return pathlib.Path.home() / ".cache" / "libvcs-test"
+
+
+def get_vcs_version(cmd: list[str]) -> str:
+    """Get version string from a VCS command, or 'not-installed' if unavailable."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "not-installed"
+
+
+def get_cache_key() -> str:
+    """Generate cache key from VCS versions and libvcs version.
+
+    The cache is invalidated when any VCS tool or libvcs version changes.
+    Results are cached to disk with a ~23.5-hour TTL to avoid slow `hg --version`
+    calls (which take ~100ms due to Python startup overhead).
+
+    Uses atomic file operations to prevent race conditions with parallel workers.
+    """
+    base_dir = get_xdg_cache_dir()
+    key_file = base_dir / ".cache_key"
+
+    # Try to return cached key (atomic read with full error handling)
+    # No exists() check - let stat() fail naturally to avoid TOCTOU race
+    try:
+        stat = key_file.stat()
+        # Use 23.5 hours (not 24) to avoid exact boundary race conditions
+        if time.time() - stat.st_mtime < 84600:
+            cached_key = key_file.read_text().strip()
+            # Validate format before using (guards against corruption)
+            if len(cached_key) == 12:
+                return cached_key
+    except (OSError, ValueError):
+        pass  # File missing, stale, corrupt, or race condition - regenerate
+
+    # Compute fresh key from VCS versions
+    versions = [
+        get_vcs_version(["git", "--version"]),
+        get_vcs_version(["hg", "--version"]),  # ~100ms due to Python startup
+        get_vcs_version(["svn", "--version"]),
+        get_package_version("libvcs"),
+    ]
+    version_str = "|".join(versions)
+    cache_key = hashlib.sha256(version_str.encode()).hexdigest()[:12]
+
+    # Atomic write: write to temp file, then rename (atomic on POSIX)
+    try:
+        base_dir.mkdir(parents=True, exist_ok=True)
+        tmp_file = base_dir / f".cache_key.{os.getpid()}.tmp"
+        tmp_file.write_text(cache_key)
+        tmp_file.rename(key_file)
+    except OSError:
+        pass  # Cache write failed, continue without caching
+
+    return cache_key
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add libvcs pytest options."""
+    group = parser.getgroup("libvcs", "libvcs fixture options")
+    group.addoption(
+        "--libvcs-cache-dir",
+        action="store",
+        metavar="PATH",
+        help="Override XDG cache directory for libvcs test fixtures",
+    )
+    group.addoption(
+        "--libvcs-clear-cache",
+        action="store_true",
+        default=False,
+        help="Clear libvcs persistent cache before running tests",
+    )
 
 
 DEFAULT_VCS_NAME = "Test user"
@@ -78,6 +235,43 @@ def git_commit_envvars(vcs_name: str, vcs_email: str) -> GitCommitEnvVars:
         "GIT_COMMITTER_NAME": vcs_name,
         "GIT_COMMITTER_EMAIL": vcs_email,
     }
+
+
+@pytest.fixture(scope="session")
+def libvcs_persistent_cache(request: pytest.FixtureRequest) -> pathlib.Path:
+    """Return persistent cache directory for libvcs test fixtures.
+
+    This cache persists across test sessions and is keyed by VCS + libvcs versions.
+    When any version changes, the cache is automatically invalidated.
+
+    The cache location follows XDG Base Directory spec:
+    - Default: ~/.cache/libvcs-test/<cache-key>/
+    - Override: --libvcs-cache-dir=PATH
+
+    Use --libvcs-clear-cache to force cache rebuild.
+    """
+    # Get cache directory (from option or XDG default)
+    custom_cache = request.config.getoption("--libvcs-cache-dir")
+    base_dir = pathlib.Path(custom_cache) if custom_cache else get_xdg_cache_dir()
+
+    # Get version-based cache key
+    cache_key = get_cache_key()
+    cache_dir = base_dir / cache_key
+
+    # Handle --libvcs-clear-cache
+    if request.config.getoption("--libvcs-clear-cache") and base_dir.exists():
+        shutil.rmtree(base_dir)
+
+    # NOTE: Automatic cleanup of old cache versions removed to prevent race
+    # conditions with pytest-xdist parallel workers. Old cache versions may
+    # accumulate but won't cause issues. Users can clean manually:
+    #   rm -rf ~/.cache/libvcs-test/*
+    # Or use: --libvcs-clear-cache
+
+    # Create cache directory
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    return cache_dir
 
 
 class RandomStrSequence:
@@ -237,17 +431,15 @@ def projects_path(
 
 @pytest.fixture(scope="session")
 def remote_repos_path(
-    user_path: pathlib.Path,
-    request: pytest.FixtureRequest,
+    libvcs_persistent_cache: pathlib.Path,
 ) -> pathlib.Path:
-    """System's remote (file-based) repos to clone and push to. Emphemeral directory."""
-    path = user_path / "remote_repos"
+    """Directory for remote repos and master copies, using persistent XDG cache.
+
+    This ensures stable file:// URLs across test sessions, enabling proper
+    caching of cloned repositories.
+    """
+    path = libvcs_persistent_cache / "remote_repos"
     path.mkdir(exist_ok=True)
-
-    def clean() -> None:
-        shutil.rmtree(path)
-
-    request.addfinalizer(clean)
     return path
 
 
@@ -320,9 +512,15 @@ def _create_git_remote_repo(
 
 
 @pytest.fixture(scope="session")
-def libvcs_test_cache_path(tmp_path_factory: pytest.TempPathFactory) -> pathlib.Path:
-    """Return temporary directory to use as cache path for libvcs tests."""
-    return tmp_path_factory.mktemp("libvcs-test-cache")
+def libvcs_test_cache_path(
+    libvcs_persistent_cache: pathlib.Path,
+) -> pathlib.Path:
+    """Return persistent cache directory for libvcs test fixtures.
+
+    This now uses XDG persistent cache, which survives across test sessions
+    and is automatically invalidated when VCS or libvcs versions change.
+    """
+    return libvcs_persistent_cache
 
 
 @pytest.fixture(scope="session")
@@ -457,17 +655,30 @@ def git_remote_repo_single_commit_post_init(
 @pytest.fixture(scope="session")
 @skip_if_git_missing
 def git_remote_repo(
-    create_git_remote_repo: CreateRepoFn,
+    remote_repos_path: pathlib.Path,
+    empty_git_repo: pathlib.Path,
     gitconfig: pathlib.Path,
     git_commit_envvars: GitCommitEnvVars,
 ) -> pathlib.Path:
-    """Copy the session-scoped Git repository to a temporary directory."""
-    # TODO: Cache the effect of of this in a session-based repo
-    repo_path = create_git_remote_repo()
-    git_remote_repo_single_commit_post_init(
-        remote_repo_path=repo_path,
-        env=git_commit_envvars,
-    )
+    """Return cached Git remote repo with an initial commit.
+
+    Uses persistent XDG cache - repo persists across test sessions.
+    Uses atomic file locking for pytest-xdist worker coordination.
+    """
+    repo_path = remote_repos_path / "git_remote_repo"
+
+    # Fast path: already initialized
+    if (repo_path / ".libvcs_initialized").exists():
+        return repo_path
+
+    def do_init() -> None:
+        shutil.copytree(empty_git_repo, repo_path)
+        git_remote_repo_single_commit_post_init(
+            remote_repo_path=repo_path,
+            env=git_commit_envvars,
+        )
+
+    atomic_init(repo_path, do_init, marker_name=".libvcs_initialized")
     return repo_path
 
 
@@ -574,20 +785,49 @@ def create_svn_remote_repo(
 @pytest.fixture(scope="session")
 @skip_if_svn_missing
 def svn_remote_repo(
-    create_svn_remote_repo: CreateRepoFn,
+    remote_repos_path: pathlib.Path,
+    empty_svn_repo: pathlib.Path,
 ) -> pathlib.Path:
-    """Pre-made. Local file:// based SVN server."""
-    return create_svn_remote_repo()
+    """Return cached SVN remote repo.
+
+    Uses persistent XDG cache - repo persists across test sessions.
+    Uses atomic file locking for pytest-xdist worker coordination.
+    """
+    repo_path = remote_repos_path / "svn_remote_repo"
+
+    # Fast path: already initialized
+    if (repo_path / ".libvcs_initialized").exists():
+        return repo_path
+
+    def do_init() -> None:
+        shutil.copytree(empty_svn_repo, repo_path)
+
+    atomic_init(repo_path, do_init, marker_name=".libvcs_initialized")
+    return repo_path
 
 
 @pytest.fixture(scope="session")
 @skip_if_svn_missing
 def svn_remote_repo_with_files(
-    create_svn_remote_repo: CreateRepoFn,
+    remote_repos_path: pathlib.Path,
+    svn_remote_repo: pathlib.Path,
 ) -> pathlib.Path:
-    """Pre-made. Local file:// based SVN server."""
-    repo_path = create_svn_remote_repo()
-    svn_remote_repo_single_commit_post_init(remote_repo_path=repo_path)
+    """Return cached SVN remote repo with files committed.
+
+    Uses persistent XDG cache - repo persists across test sessions.
+    Uses atomic file locking for pytest-xdist worker coordination.
+    """
+    repo_path = remote_repos_path / "svn_remote_repo_with_files"
+
+    # Fast path: already initialized
+    if (repo_path / ".libvcs_initialized").exists():
+        return repo_path
+
+    def do_init() -> None:
+        shutil.copytree(svn_remote_repo, repo_path)
+        svn_remote_repo_single_commit_post_init(remote_repo_path=repo_path)
+
+    atomic_init(repo_path, do_init, marker_name=".libvcs_initialized")
     return repo_path
 
 
@@ -684,15 +924,29 @@ def create_hg_remote_repo(
 @skip_if_hg_missing
 def hg_remote_repo(
     remote_repos_path: pathlib.Path,
-    create_hg_remote_repo: CreateRepoFn,
+    empty_hg_repo: pathlib.Path,
     hgconfig: pathlib.Path,
 ) -> pathlib.Path:
-    """Pre-made, file-based repo for push and pull."""
-    repo_path = create_hg_remote_repo()
-    hg_remote_repo_single_commit_post_init(
-        remote_repo_path=repo_path,
-        env={"HGRCPATH": str(hgconfig)},
-    )
+    """Return cached Mercurial remote repo with an initial commit.
+
+    Uses persistent XDG cache - repo persists across test sessions.
+    Uses atomic file locking for pytest-xdist worker coordination.
+    """
+    repo_path = remote_repos_path / "hg_remote_repo"
+
+    # Fast path: already initialized
+    if (repo_path / ".libvcs_initialized").exists():
+        return repo_path
+
+    def do_init() -> None:
+        shutil.copytree(empty_hg_repo, repo_path)
+        # Add initial commit (slow: ~288ms due to hg add + commit)
+        hg_remote_repo_single_commit_post_init(
+            remote_repo_path=repo_path,
+            env={"HGRCPATH": str(hgconfig)},
+        )
+
+    atomic_init(repo_path, do_init, marker_name=".libvcs_initialized")
     return repo_path
 
 
@@ -703,32 +957,56 @@ def git_repo(
     git_remote_repo: pathlib.Path,
     set_gitconfig: pathlib.Path,
     set_home: None,  # Needed for child processes (e.g. submodules)
-) -> GitSync:
-    """Pre-made git clone of remote repo checked out to user's projects dir."""
+) -> RepoFixtureResult[GitSync]:
+    """Pre-made git clone of remote repo checked out to user's projects dir.
+
+    Returns a RepoFixtureResult containing the GitSync instance and metadata.
+    The underlying GitSync methods are accessible directly via __getattr__.
+    """
+    created_at = time.perf_counter()
     remote_repo_name = unique_repo_name(remote_repos_path=projects_path)
     new_checkout_path = projects_path / remote_repo_name
-    master_copy = remote_repos_path / "git_repo"
+    remote_url = f"file://{git_remote_repo}"
+    # Unified master copy shared with async_git_repo
+    master_copy = remote_repos_path / "git_repo_master"
 
-    if master_copy.exists():
-        shutil.copytree(master_copy, new_checkout_path)
-        return GitSync(
-            url=f"file://{git_remote_repo}",
-            path=str(new_checkout_path),
+    def create_master() -> None:
+        """Create master copy atomically - only one worker does this."""
+        repo = GitSync(
+            url=remote_url,
+            path=master_copy,
+            remotes={
+                "origin": GitRemote(
+                    name="origin",
+                    push_url=remote_url,
+                    fetch_url=remote_url,
+                ),
+            },
         )
+        repo.obtain()
 
-    git_repo = GitSync(
-        url=f"file://{git_remote_repo}",
-        path=master_copy,
-        remotes={
-            "origin": GitRemote(
-                name="origin",
-                push_url=f"file://{git_remote_repo}",
-                fetch_url=f"file://{git_remote_repo}",
-            ),
-        },
+    # atomic_init returns True if this process did the init, False if waited
+    from_cache = not atomic_init(
+        master_copy,
+        create_master,
+        marker_name=".libvcs_master_initialized",
     )
-    git_repo.obtain()
-    return git_repo
+
+    # All workers get a unique copy from master (exclude marker file)
+    shutil.copytree(
+        master_copy,
+        new_checkout_path,
+        ignore=shutil.ignore_patterns(".libvcs_master_initialized"),
+    )
+    repo = GitSync(url=remote_url, path=str(new_checkout_path))
+    return RepoFixtureResult(
+        repo=repo,
+        path=new_checkout_path,
+        remote_url=remote_url,
+        master_copy_path=master_copy,
+        created_at=created_at,
+        from_cache=from_cache,
+    )
 
 
 @pytest.fixture
@@ -737,25 +1015,45 @@ def hg_repo(
     projects_path: pathlib.Path,
     hg_remote_repo: pathlib.Path,
     set_hgconfig: pathlib.Path,
-) -> HgSync:
-    """Pre-made hg clone of remote repo checked out to user's projects dir."""
+) -> RepoFixtureResult[HgSync]:
+    """Pre-made hg clone of remote repo checked out to user's projects dir.
+
+    Returns a RepoFixtureResult containing the HgSync instance and metadata.
+    """
+    created_at = time.perf_counter()
     remote_repo_name = unique_repo_name(remote_repos_path=projects_path)
     new_checkout_path = projects_path / remote_repo_name
-    master_copy = remote_repos_path / "hg_repo"
+    remote_url = f"file://{hg_remote_repo}"
+    # Unified master copy shared with async_hg_repo
+    master_copy = remote_repos_path / "hg_repo_master"
 
-    if master_copy.exists():
-        shutil.copytree(master_copy, new_checkout_path)
-        return HgSync(
-            url=f"file://{hg_remote_repo}",
-            path=str(new_checkout_path),
-        )
+    def create_master() -> None:
+        """Create master copy atomically - only one worker does this."""
+        repo = HgSync(url=remote_url, path=master_copy)
+        repo.obtain()
 
-    hg_repo = HgSync(
-        url=f"file://{hg_remote_repo}",
-        path=master_copy,
+    # atomic_init returns True if this process did the init, False if waited
+    from_cache = not atomic_init(
+        master_copy,
+        create_master,
+        marker_name=".libvcs_master_initialized",
     )
-    hg_repo.obtain()
-    return hg_repo
+
+    # All workers get a unique copy from master (exclude marker file)
+    shutil.copytree(
+        master_copy,
+        new_checkout_path,
+        ignore=shutil.ignore_patterns(".libvcs_master_initialized"),
+    )
+    repo = HgSync(url=remote_url, path=str(new_checkout_path))
+    return RepoFixtureResult(
+        repo=repo,
+        path=new_checkout_path,
+        remote_url=remote_url,
+        master_copy_path=master_copy,
+        created_at=created_at,
+        from_cache=from_cache,
+    )
 
 
 @pytest.fixture
@@ -763,25 +1061,45 @@ def svn_repo(
     remote_repos_path: pathlib.Path,
     projects_path: pathlib.Path,
     svn_remote_repo: pathlib.Path,
-) -> SvnSync:
-    """Pre-made svn clone of remote repo checked out to user's projects dir."""
+) -> RepoFixtureResult[SvnSync]:
+    """Pre-made svn checkout of remote repo checked out to user's projects dir.
+
+    Returns a RepoFixtureResult containing the SvnSync instance and metadata.
+    """
+    created_at = time.perf_counter()
     remote_repo_name = unique_repo_name(remote_repos_path=projects_path)
     new_checkout_path = projects_path / remote_repo_name
-    master_copy = remote_repos_path / "svn_repo"
+    remote_url = f"file://{svn_remote_repo}"
+    # Unified master copy shared with async_svn_repo
+    master_copy = remote_repos_path / "svn_repo_master"
 
-    if master_copy.exists():
-        shutil.copytree(master_copy, new_checkout_path)
-        return SvnSync(
-            url=f"file://{svn_remote_repo}",
-            path=str(new_checkout_path),
-        )
+    def create_master() -> None:
+        """Create master copy atomically - only one worker does this."""
+        repo = SvnSync(url=remote_url, path=str(master_copy))
+        repo.obtain()
 
-    svn_repo = SvnSync(
-        url=f"file://{svn_remote_repo}",
-        path=str(projects_path / "svn_repo"),
+    # atomic_init returns True if this process did the init, False if waited
+    from_cache = not atomic_init(
+        master_copy,
+        create_master,
+        marker_name=".libvcs_master_initialized",
     )
-    svn_repo.obtain()
-    return svn_repo
+
+    # All workers get a unique copy from master (exclude marker file)
+    shutil.copytree(
+        master_copy,
+        new_checkout_path,
+        ignore=shutil.ignore_patterns(".libvcs_master_initialized"),
+    )
+    repo = SvnSync(url=remote_url, path=str(new_checkout_path))
+    return RepoFixtureResult(
+        repo=repo,
+        path=new_checkout_path,
+        remote_url=remote_url,
+        master_copy_path=master_copy,
+        created_at=created_at,
+        from_cache=from_cache,
+    )
 
 
 @pytest.fixture

--- a/tests/_internal/test_file_lock.py
+++ b/tests/_internal/test_file_lock.py
@@ -1,0 +1,693 @@
+"""Tests for libvcs._internal.file_lock."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pickle  # Used to test exception picklability for multiprocessing support
+import threading
+import time
+import typing as t
+from pathlib import Path
+
+import pytest
+
+from libvcs._internal.file_lock import (
+    AcquireReturnProxy,
+    AsyncAcquireReturnProxy,
+    AsyncFileLock,
+    FileLock,
+    FileLockContext,
+    FileLockError,
+    FileLockStale,
+    FileLockTimeout,
+    async_atomic_init,
+    atomic_init,
+)
+
+# =============================================================================
+# FileLock Sync Tests
+# =============================================================================
+
+
+class LockAcquireFixture(t.NamedTuple):
+    """Test fixture for FileLock acquisition scenarios."""
+
+    test_id: str
+    timeout: float
+    should_acquire: bool
+    description: str
+
+
+LOCK_ACQUIRE_FIXTURES = [
+    LockAcquireFixture(
+        test_id="default_timeout",
+        timeout=-1.0,
+        should_acquire=True,
+        description="Acquire with infinite timeout",
+    ),
+    LockAcquireFixture(
+        test_id="explicit_timeout",
+        timeout=5.0,
+        should_acquire=True,
+        description="Acquire with 5s timeout",
+    ),
+    LockAcquireFixture(
+        test_id="zero_timeout",
+        timeout=0.0,
+        should_acquire=True,
+        description="Non-blocking acquire on free lock",
+    ),
+]
+
+
+class TestFileLock:
+    """Tests for FileLock synchronous operations."""
+
+    @pytest.mark.parametrize(
+        list(LockAcquireFixture._fields),
+        LOCK_ACQUIRE_FIXTURES,
+        ids=[f.test_id for f in LOCK_ACQUIRE_FIXTURES],
+    )
+    def test_acquire_scenarios(
+        self,
+        tmp_path: Path,
+        test_id: str,
+        timeout: float,
+        should_acquire: bool,
+        description: str,
+    ) -> None:
+        """Test various lock acquisition scenarios."""
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path, timeout=timeout)
+
+        if should_acquire:
+            with lock:
+                assert lock.is_locked
+                assert lock.lock_counter == 1
+            assert not lock.is_locked
+
+    def test_context_manager(self, tmp_path: Path) -> None:
+        """Test FileLock as context manager."""
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path)
+
+        assert not lock.is_locked
+        with lock:
+            assert lock.is_locked
+            assert lock_path.exists()
+        assert not lock.is_locked
+        assert not lock_path.exists()
+
+    def test_explicit_acquire_release(self, tmp_path: Path) -> None:
+        """Test explicit acquire() and release()."""
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path)
+
+        proxy = lock.acquire()
+        assert isinstance(proxy, AcquireReturnProxy)
+        assert lock.is_locked
+        assert lock.lock_counter == 1
+
+        lock.release()
+        assert not lock.is_locked
+        assert lock.lock_counter == 0
+
+    def test_reentrant_locking(self, tmp_path: Path) -> None:
+        """Test reentrant lock acquisition."""
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path)
+
+        lock.acquire()
+        assert lock.lock_counter == 1
+
+        lock.acquire()
+        assert lock.lock_counter == 2
+
+        lock.acquire()
+        assert lock.lock_counter == 3
+
+        lock.release()
+        assert lock.lock_counter == 2
+        assert lock.is_locked
+
+        lock.release()
+        assert lock.lock_counter == 1
+        assert lock.is_locked
+
+        lock.release()
+        assert lock.lock_counter == 0
+        assert not lock.is_locked
+
+    def test_force_release(self, tmp_path: Path) -> None:
+        """Test force=True releases regardless of counter."""
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path)
+
+        lock.acquire()
+        lock.acquire()
+        lock.acquire()
+        assert lock.lock_counter == 3
+
+        lock.release(force=True)
+        assert lock.lock_counter == 0
+        assert not lock.is_locked
+
+    def test_non_blocking_acquire(self, tmp_path: Path) -> None:
+        """Test non-blocking acquire with blocking=False."""
+        lock_path = tmp_path / "test.lock"
+
+        # First lock acquires
+        lock1 = FileLock(lock_path)
+        lock1.acquire()
+
+        # Second lock should fail immediately
+        lock2 = FileLock(lock_path)
+        with pytest.raises(FileLockTimeout):
+            lock2.acquire(blocking=False)
+
+        lock1.release()
+
+    def test_timeout_on_held_lock(self, tmp_path: Path) -> None:
+        """Test timeout when lock is held by another process."""
+        lock_path = tmp_path / "test.lock"
+
+        # Hold the lock
+        lock1 = FileLock(lock_path)
+        lock1.acquire()
+
+        # Try to acquire with short timeout
+        lock2 = FileLock(lock_path, timeout=0.1)
+        with pytest.raises(FileLockTimeout) as exc_info:
+            lock2.acquire()
+
+        assert exc_info.value.lock_file == str(lock_path)
+        assert exc_info.value.timeout == 0.1
+
+        lock1.release()
+
+    def test_pid_written_to_lock_file(self, tmp_path: Path) -> None:
+        """Test PID is written to lock file for debugging."""
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path)
+
+        with lock:
+            content = lock_path.read_text()
+            assert content == str(os.getpid())
+
+    def test_acquire_return_proxy_context(self, tmp_path: Path) -> None:
+        """Test AcquireReturnProxy as context manager."""
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path)
+
+        with lock.acquire() as acquired_lock:
+            assert acquired_lock is lock
+            assert lock.is_locked
+
+        assert not lock.is_locked
+
+    def test_lock_file_property(self, tmp_path: Path) -> None:
+        """Test lock_file property returns path."""
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path)
+
+        assert lock.lock_file == str(lock_path)
+
+    def test_repr(self, tmp_path: Path) -> None:
+        """Test __repr__ shows lock state."""
+        lock_path = tmp_path / "test.lock"
+        lock = FileLock(lock_path)
+
+        assert "unlocked" in repr(lock)
+        with lock:
+            assert "locked" in repr(lock)
+
+
+class StaleLockFixture(t.NamedTuple):
+    """Test fixture for stale lock scenarios."""
+
+    test_id: str
+    stale_timeout: float
+    sleep_time: float
+    should_acquire: bool
+
+
+STALE_LOCK_FIXTURES = [
+    StaleLockFixture(
+        test_id="fresh_lock_blocks",
+        stale_timeout=1.0,
+        sleep_time=0.0,
+        should_acquire=False,
+    ),
+    StaleLockFixture(
+        test_id="stale_lock_acquired",
+        stale_timeout=0.1,
+        sleep_time=0.2,
+        should_acquire=True,
+    ),
+]
+
+
+class TestFileLockStaleDetection:
+    """Tests for stale lock detection and removal."""
+
+    @pytest.mark.parametrize(
+        list(StaleLockFixture._fields),
+        STALE_LOCK_FIXTURES,
+        ids=[f.test_id for f in STALE_LOCK_FIXTURES],
+    )
+    def test_stale_detection(
+        self,
+        tmp_path: Path,
+        test_id: str,
+        stale_timeout: float,
+        sleep_time: float,
+        should_acquire: bool,
+    ) -> None:
+        """Test stale lock detection scenarios."""
+        lock_path = tmp_path / "test.lock"
+
+        # Create a lock file manually (simulating orphaned lock)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(str(os.getpid()))
+
+        if sleep_time > 0:
+            time.sleep(sleep_time)
+
+        lock = FileLock(lock_path, timeout=0.05, stale_timeout=stale_timeout)
+
+        if should_acquire:
+            with lock:
+                assert lock.is_locked
+        else:
+            with pytest.raises(FileLockTimeout):
+                lock.acquire()
+
+
+# =============================================================================
+# AsyncFileLock Tests
+# =============================================================================
+
+
+class TestAsyncFileLock:
+    """Tests for AsyncFileLock asynchronous operations."""
+
+    @pytest.mark.asyncio
+    async def test_async_context_manager(self, tmp_path: Path) -> None:
+        """Test AsyncFileLock as async context manager."""
+        lock_path = tmp_path / "test.lock"
+        lock = AsyncFileLock(lock_path)
+
+        assert not lock.is_locked
+        async with lock:
+            assert lock.is_locked
+            assert lock_path.exists()
+        assert not lock.is_locked
+
+    @pytest.mark.asyncio
+    async def test_async_explicit_acquire_release(self, tmp_path: Path) -> None:
+        """Test explicit acquire() and release() for async lock."""
+        lock_path = tmp_path / "test.lock"
+        lock = AsyncFileLock(lock_path)
+
+        proxy = await lock.acquire()
+        assert isinstance(proxy, AsyncAcquireReturnProxy)
+        assert lock.is_locked
+
+        await lock.release()
+        assert not lock.is_locked
+
+    @pytest.mark.asyncio
+    async def test_async_reentrant(self, tmp_path: Path) -> None:
+        """Test async reentrant locking."""
+        lock_path = tmp_path / "test.lock"
+        lock = AsyncFileLock(lock_path)
+
+        await lock.acquire()
+        assert lock.lock_counter == 1
+
+        await lock.acquire()
+        assert lock.lock_counter == 2
+
+        await lock.release()
+        assert lock.lock_counter == 1
+
+        await lock.release()
+        assert lock.lock_counter == 0
+
+    @pytest.mark.asyncio
+    async def test_async_timeout(self, tmp_path: Path) -> None:
+        """Test async lock timeout."""
+        lock_path = tmp_path / "test.lock"
+
+        lock1 = AsyncFileLock(lock_path)
+        await lock1.acquire()
+
+        lock2 = AsyncFileLock(lock_path, timeout=0.1)
+        with pytest.raises(FileLockTimeout):
+            await lock2.acquire()
+
+        await lock1.release()
+
+    @pytest.mark.asyncio
+    async def test_async_non_blocking(self, tmp_path: Path) -> None:
+        """Test async non-blocking acquire."""
+        lock_path = tmp_path / "test.lock"
+
+        lock1 = AsyncFileLock(lock_path)
+        await lock1.acquire()
+
+        lock2 = AsyncFileLock(lock_path)
+        with pytest.raises(FileLockTimeout):
+            await lock2.acquire(blocking=False)
+
+        await lock1.release()
+
+    @pytest.mark.asyncio
+    async def test_async_acquire_proxy_context(self, tmp_path: Path) -> None:
+        """Test AsyncAcquireReturnProxy as async context manager."""
+        lock_path = tmp_path / "test.lock"
+        lock = AsyncFileLock(lock_path)
+
+        proxy = await lock.acquire()
+        async with proxy as acquired_lock:
+            assert acquired_lock is lock
+            assert lock.is_locked
+
+        assert not lock.is_locked
+
+    @pytest.mark.asyncio
+    async def test_async_concurrent_acquisition(self, tmp_path: Path) -> None:
+        """Test concurrent async lock acquisition."""
+        lock_path = tmp_path / "test.lock"
+        results: list[int] = []
+
+        async def worker(lock: AsyncFileLock, worker_id: int) -> None:
+            async with lock:
+                results.append(worker_id)
+                await asyncio.sleep(0.01)
+
+        lock = AsyncFileLock(lock_path)
+        await asyncio.gather(*[worker(lock, i) for i in range(3)])
+
+        # All workers should have completed
+        assert len(results) == 3
+        # Results should be sequential (one at a time)
+        assert sorted(results) == list(range(3))
+
+    @pytest.mark.asyncio
+    async def test_async_repr(self, tmp_path: Path) -> None:
+        """Test __repr__ for async lock."""
+        lock_path = tmp_path / "test.lock"
+        lock = AsyncFileLock(lock_path)
+
+        assert "unlocked" in repr(lock)
+        async with lock:
+            assert "locked" in repr(lock)
+
+
+# =============================================================================
+# FileLockContext Tests
+# =============================================================================
+
+
+class TestFileLockContext:
+    """Tests for FileLockContext dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test default values are set correctly."""
+        ctx = FileLockContext("/tmp/test.lock")
+
+        assert ctx.lock_file == "/tmp/test.lock"
+        assert ctx.timeout == -1.0
+        assert ctx.poll_interval == 0.05
+        assert ctx.stale_timeout == 300.0
+        assert ctx.mode == 0o644
+        assert ctx.lock_file_fd is None
+        assert ctx.lock_counter == 0
+
+    def test_is_locked_property(self) -> None:
+        """Test is_locked property."""
+        ctx = FileLockContext("/tmp/test.lock")
+
+        assert not ctx.is_locked
+
+        ctx.lock_file_fd = 5
+        assert ctx.is_locked
+
+
+# =============================================================================
+# Exception Tests
+# =============================================================================
+
+
+class TestExceptions:
+    """Tests for exception classes."""
+
+    def test_file_lock_timeout_message(self) -> None:
+        """Test FileLockTimeout message format."""
+        exc = FileLockTimeout("/tmp/test.lock", 30.0)
+
+        assert str(exc) == "Timeout (30.0s) waiting for lock: /tmp/test.lock"
+        assert exc.lock_file == "/tmp/test.lock"
+        assert exc.timeout == 30.0
+
+    def test_file_lock_timeout_inheritance(self) -> None:
+        """Test FileLockTimeout inherits from TimeoutError."""
+        exc = FileLockTimeout("/tmp/test.lock", 30.0)
+
+        assert isinstance(exc, FileLockError)
+        assert isinstance(exc, TimeoutError)
+
+    def test_file_lock_timeout_picklable(self) -> None:
+        """Test FileLockTimeout is picklable for multiprocessing support."""
+        exc = FileLockTimeout("/tmp/test.lock", 30.0)
+        pickled = pickle.dumps(exc)
+        restored = pickle.loads(pickled)
+
+        assert restored.lock_file == exc.lock_file
+        assert restored.timeout == exc.timeout
+
+    def test_file_lock_stale_message(self) -> None:
+        """Test FileLockStale message format."""
+        exc = FileLockStale("/tmp/test.lock", 3600.0)
+
+        assert str(exc) == "Stale lock (3600.0s old): /tmp/test.lock"
+        assert exc.lock_file == "/tmp/test.lock"
+        assert exc.age_seconds == 3600.0
+
+    def test_file_lock_stale_picklable(self) -> None:
+        """Test FileLockStale is picklable for multiprocessing support."""
+        exc = FileLockStale("/tmp/test.lock", 3600.0)
+        pickled = pickle.dumps(exc)
+        restored = pickle.loads(pickled)
+
+        assert restored.lock_file == exc.lock_file
+        assert restored.age_seconds == exc.age_seconds
+
+
+# =============================================================================
+# atomic_init Tests
+# =============================================================================
+
+
+class AtomicInitFixture(t.NamedTuple):
+    """Test fixture for atomic_init scenarios."""
+
+    test_id: str
+    pre_initialized: bool
+    expected_result: bool
+    description: str
+
+
+ATOMIC_INIT_FIXTURES = [
+    AtomicInitFixture(
+        test_id="first_init",
+        pre_initialized=False,
+        expected_result=True,
+        description="First call performs initialization",
+    ),
+    AtomicInitFixture(
+        test_id="already_initialized",
+        pre_initialized=True,
+        expected_result=False,
+        description="Already initialized returns False",
+    ),
+]
+
+
+class TestAtomicInit:
+    """Tests for atomic_init function."""
+
+    @pytest.mark.parametrize(
+        list(AtomicInitFixture._fields),
+        ATOMIC_INIT_FIXTURES,
+        ids=[f.test_id for f in ATOMIC_INIT_FIXTURES],
+    )
+    def test_atomic_init_scenarios(
+        self,
+        tmp_path: Path,
+        test_id: str,
+        pre_initialized: bool,
+        expected_result: bool,
+        description: str,
+    ) -> None:
+        """Test atomic_init return values."""
+        resource_path = tmp_path / "resource"
+        resource_path.mkdir()
+        marker = resource_path / ".initialized"
+
+        if pre_initialized:
+            marker.touch()
+
+        init_called = []
+
+        def init_fn() -> None:
+            init_called.append(True)
+
+        result = atomic_init(resource_path, init_fn)
+
+        assert result == expected_result
+        if expected_result:
+            assert len(init_called) == 1
+        else:
+            assert len(init_called) == 0
+        assert marker.exists()
+
+    def test_atomic_init_creates_marker(self, tmp_path: Path) -> None:
+        """Test atomic_init creates marker file."""
+        resource_path = tmp_path / "resource"
+        resource_path.mkdir()
+
+        atomic_init(resource_path, lambda: None)
+
+        assert (resource_path / ".initialized").exists()
+
+    def test_atomic_init_custom_marker(self, tmp_path: Path) -> None:
+        """Test atomic_init with custom marker name."""
+        resource_path = tmp_path / "resource"
+        resource_path.mkdir()
+
+        atomic_init(resource_path, lambda: None, marker_name=".custom_marker")
+
+        assert (resource_path / ".custom_marker").exists()
+        assert not (resource_path / ".initialized").exists()
+
+    def test_atomic_init_cleans_partial_state(self, tmp_path: Path) -> None:
+        """Test atomic_init cleans partial state before init."""
+        resource_path = tmp_path / "resource"
+        resource_path.mkdir()
+        # Create partial state (no marker)
+        (resource_path / "partial_file.txt").write_text("partial")
+
+        def init_fn() -> None:
+            (resource_path / "complete_file.txt").write_text("complete")
+
+        atomic_init(resource_path, init_fn)
+
+        # Partial file should be gone, complete file should exist
+        assert not (resource_path / "partial_file.txt").exists()
+        assert (resource_path / "complete_file.txt").exists()
+
+    def test_atomic_init_concurrent(self, tmp_path: Path) -> None:
+        """Test atomic_init handles concurrent calls."""
+        resource_path = tmp_path / "resource"
+        resource_path.mkdir()
+        init_count = {"count": 0}
+        lock = threading.Lock()
+
+        def init_fn() -> None:
+            with lock:
+                init_count["count"] += 1
+            time.sleep(0.1)  # Simulate slow init
+
+        threads = []
+        for _ in range(5):
+            t = threading.Thread(target=atomic_init, args=(resource_path, init_fn))
+            threads.append(t)
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # Only one thread should have initialized
+        assert init_count["count"] == 1
+
+
+# =============================================================================
+# async_atomic_init Tests
+# =============================================================================
+
+
+class TestAsyncAtomicInit:
+    """Tests for async_atomic_init function."""
+
+    @pytest.mark.asyncio
+    async def test_async_atomic_init_first(self, tmp_path: Path) -> None:
+        """Test first async_atomic_init performs initialization."""
+        resource_path = tmp_path / "resource"
+        resource_path.mkdir()
+        init_called = []
+
+        async def async_init_fn() -> None:
+            init_called.append(True)
+            await asyncio.sleep(0)
+
+        result = await async_atomic_init(resource_path, async_init_fn)
+
+        assert result is True
+        assert len(init_called) == 1
+        assert (resource_path / ".initialized").exists()
+
+    @pytest.mark.asyncio
+    async def test_async_atomic_init_already_done(self, tmp_path: Path) -> None:
+        """Test async_atomic_init skips when already initialized."""
+        resource_path = tmp_path / "resource"
+        resource_path.mkdir()
+        (resource_path / ".initialized").touch()
+
+        init_called = []
+
+        async def async_init_fn() -> None:
+            init_called.append(True)
+
+        result = await async_atomic_init(resource_path, async_init_fn)
+
+        assert result is False
+        assert len(init_called) == 0
+
+    @pytest.mark.asyncio
+    async def test_async_atomic_init_sync_fn(self, tmp_path: Path) -> None:
+        """Test async_atomic_init works with sync init function."""
+        resource_path = tmp_path / "resource"
+        resource_path.mkdir()
+        init_called = []
+
+        def sync_init_fn() -> None:
+            init_called.append(True)
+
+        result = await async_atomic_init(resource_path, sync_init_fn)
+
+        assert result is True
+        assert len(init_called) == 1
+
+    @pytest.mark.asyncio
+    async def test_async_atomic_init_concurrent(self, tmp_path: Path) -> None:
+        """Test async_atomic_init handles concurrent calls."""
+        resource_path = tmp_path / "resource"
+        resource_path.mkdir()
+        init_count = {"count": 0}
+
+        async def init_fn() -> None:
+            init_count["count"] += 1
+            await asyncio.sleep(0.1)  # Simulate slow init
+
+        results = await asyncio.gather(
+            *[async_atomic_init(resource_path, init_fn) for _ in range(5)]
+        )
+
+        # Only one should have returned True
+        assert sum(results) == 1
+        # Only one init should have run
+        assert init_count["count"] == 1

--- a/tests/test_fixture_performance.py
+++ b/tests/test_fixture_performance.py
@@ -1,0 +1,615 @@
+"""Performance tests for libvcs pytest fixtures.
+
+These tests verify that fixture caching works correctly and measures
+fixture setup times. They are skipped by default - run with --run-performance.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import typing as t
+
+import pytest
+
+from libvcs.sync.git import GitSync
+from libvcs.sync.hg import HgSync
+from libvcs.sync.svn import SvnSync
+
+if t.TYPE_CHECKING:
+    from libvcs.pytest_plugin import RepoFixtureResult
+
+
+# =============================================================================
+# Git Fixture Performance Tests
+# =============================================================================
+
+
+@pytest.mark.performance
+def test_git_repo_fixture_uses_cache(
+    git_repo: GitSync,
+    remote_repos_path: pathlib.Path,
+) -> None:
+    """Verify git_repo fixture uses master_copy caching."""
+    master_copy = remote_repos_path / "git_repo_master"
+    assert master_copy.exists(), "master_copy should exist after fixture setup"
+    assert (master_copy / ".git").exists(), "master_copy should be a valid git repo"
+
+
+@pytest.mark.performance
+def test_git_remote_repo_uses_persistent_cache(
+    git_remote_repo: pathlib.Path,
+    libvcs_persistent_cache: pathlib.Path,
+) -> None:
+    """Verify git_remote_repo uses XDG persistent cache."""
+    assert str(libvcs_persistent_cache) in str(git_remote_repo)
+    # Non-bare repo has .git directory
+    assert (git_remote_repo / ".git").exists(), "remote should have .git directory"
+
+
+@pytest.mark.performance
+def test_git_repo_fixture_setup_time(
+    git_repo: GitSync,
+) -> None:
+    """Verify git_repo fixture setup is fast (uses cached copy)."""
+    # The fixture is already set up - this test just verifies it works
+    # The actual timing is captured by the fixture profiling hooks
+    assert git_repo.path.exists()
+
+
+@pytest.mark.performance
+def test_git_repo_fixture_provides_working_repo(
+    git_repo: GitSync,
+) -> None:
+    """Verify git_repo fixture provides a functional repository."""
+    # Should have .git directory
+    git_dir = pathlib.Path(git_repo.path) / ".git"
+    assert git_dir.exists(), "git_repo should have .git directory"
+
+    # Should be able to get revision
+    revision = git_repo.get_revision()
+    assert revision, "git_repo should have a revision"
+
+
+# =============================================================================
+# Mercurial Fixture Performance Tests
+# =============================================================================
+
+
+@pytest.mark.performance
+def test_hg_repo_fixture_uses_cache(
+    hg_repo: HgSync,
+    remote_repos_path: pathlib.Path,
+) -> None:
+    """Verify hg_repo fixture uses master_copy caching."""
+    master_copy = remote_repos_path / "hg_repo_master"
+    assert master_copy.exists(), "master_copy should exist after fixture setup"
+    assert (master_copy / ".hg").exists(), "master_copy should be a valid hg repo"
+
+
+@pytest.mark.performance
+def test_hg_remote_repo_uses_persistent_cache(
+    hg_remote_repo: pathlib.Path,
+    libvcs_persistent_cache: pathlib.Path,
+) -> None:
+    """Verify hg_remote_repo uses XDG persistent cache."""
+    assert str(libvcs_persistent_cache) in str(hg_remote_repo)
+    assert (hg_remote_repo / ".hg").exists(), "remote should have .hg"
+
+
+@pytest.mark.performance
+def test_hg_repo_fixture_provides_working_repo(
+    hg_repo: HgSync,
+) -> None:
+    """Verify hg_repo fixture provides a functional repository."""
+    hg_dir = pathlib.Path(hg_repo.path) / ".hg"
+    assert hg_dir.exists(), "hg_repo should have .hg directory"
+
+
+@pytest.mark.performance
+def test_hg_remote_repo_has_marker_file(
+    hg_remote_repo: pathlib.Path,
+) -> None:
+    """Verify hg_remote_repo uses marker file for initialization tracking."""
+    marker = hg_remote_repo / ".libvcs_initialized"
+    assert marker.exists(), "hg_remote_repo should have .libvcs_initialized marker"
+
+
+@pytest.mark.performance
+def test_hg_repo_warm_cache_is_fast(
+    hg_repo: RepoFixtureResult[HgSync],
+) -> None:
+    """Verify hg_repo warm cache uses copytree (should be <50ms).
+
+    Mercurial is inherently slow (~100ms for hg --version alone),
+    so we verify that cached runs avoid hg commands entirely.
+    """
+    # If from_cache is True, this was a copytree operation
+    if hg_repo.from_cache:
+        # created_at is relative perf_counter, but we verify it's fast
+        assert hg_repo.master_copy_path.exists()
+
+
+# =============================================================================
+# SVN Fixture Performance Tests
+# =============================================================================
+
+
+@pytest.mark.performance
+def test_svn_repo_fixture_uses_cache(
+    svn_repo: SvnSync,
+    remote_repos_path: pathlib.Path,
+) -> None:
+    """Verify svn_repo fixture uses master_copy caching."""
+    master_copy = remote_repos_path / "svn_repo_master"
+    assert master_copy.exists(), "master_copy should exist after fixture setup"
+    assert (master_copy / ".svn").exists(), "master_copy should be a valid svn checkout"
+
+
+@pytest.mark.performance
+def test_svn_remote_repo_uses_persistent_cache(
+    svn_remote_repo: pathlib.Path,
+    libvcs_persistent_cache: pathlib.Path,
+) -> None:
+    """Verify svn_remote_repo uses XDG persistent cache."""
+    assert str(libvcs_persistent_cache) in str(svn_remote_repo)
+    assert (svn_remote_repo / "format").exists(), "remote should have format file"
+
+
+@pytest.mark.performance
+def test_svn_repo_fixture_provides_working_repo(
+    svn_repo: SvnSync,
+) -> None:
+    """Verify svn_repo fixture provides a functional repository."""
+    # Should have .svn directory
+    svn_dir = pathlib.Path(svn_repo.path) / ".svn"
+    assert svn_dir.exists(), "svn_repo should have .svn directory"
+
+    # Should be able to get revision (0 is valid for initial checkout)
+    revision = svn_repo.get_revision()
+    assert revision is not None, "svn_repo should return a revision"
+
+
+@pytest.mark.performance
+def test_svn_remote_repo_has_marker_file(
+    svn_remote_repo: pathlib.Path,
+) -> None:
+    """Verify svn_remote_repo uses marker file for initialization tracking."""
+    marker = svn_remote_repo / ".libvcs_initialized"
+    assert marker.exists(), "svn_remote_repo should have .libvcs_initialized marker"
+
+
+@pytest.mark.performance
+def test_svn_repo_warm_cache_is_fast(
+    svn_repo: RepoFixtureResult[SvnSync],
+) -> None:
+    """Verify svn_repo warm cache uses copytree (should be <50ms).
+
+    SVN checkout is slow (~500ms for svn co alone),
+    so we verify that cached runs avoid svn commands entirely.
+    """
+    # If from_cache is True, this was a copytree operation
+    if svn_repo.from_cache:
+        # created_at is relative perf_counter, but we verify it's fast
+        assert svn_repo.master_copy_path.exists()
+
+
+# =============================================================================
+# Cache Invalidation Tests
+# =============================================================================
+
+
+@pytest.mark.performance
+def test_persistent_cache_has_version_key(
+    libvcs_persistent_cache: pathlib.Path,
+) -> None:
+    """Verify persistent cache uses version-based directory."""
+    # The cache path should end with a 12-char hex hash
+    cache_name = libvcs_persistent_cache.name
+    assert len(cache_name) == 12, f"cache key should be 12 chars, got: {cache_name}"
+    # Should be valid hex
+    try:
+        int(cache_name, 16)
+    except ValueError:
+        pytest.fail(f"cache key should be hex, got: {cache_name}")
+
+
+@pytest.mark.performance
+def test_persistent_cache_location_follows_xdg(
+    libvcs_persistent_cache: pathlib.Path,
+) -> None:
+    """Verify persistent cache is in XDG cache structure."""
+    # The cache should be at <xdg_cache>/libvcs-test/<hash>/
+    # We verify the structure rather than exact path (since HOME is monkeypatched)
+    assert libvcs_persistent_cache.parent.name == "libvcs-test"
+    # Cache key should be 12-char hex
+    assert len(libvcs_persistent_cache.name) == 12
+
+
+@pytest.mark.performance
+def test_version_key_is_cached_to_disk(
+    libvcs_persistent_cache: pathlib.Path,
+) -> None:
+    """Verify VCS version detection is cached to disk.
+
+    This optimization avoids running slow `hg --version` (102ms) on every
+    pytest session by caching the computed cache key to disk with 24h TTL.
+    """
+    cache_key_file = libvcs_persistent_cache.parent / ".cache_key"
+    assert cache_key_file.exists(), ".cache_key file should exist"
+    # Should contain the same 12-char hex key as the cache directory name
+    cached_key = cache_key_file.read_text().strip()
+    assert cached_key == libvcs_persistent_cache.name
+
+
+# =============================================================================
+# Multiple Fixture Usage Tests
+# =============================================================================
+
+
+@pytest.mark.performance
+def test_multiple_git_repo_instances_are_isolated(
+    git_repo: GitSync,
+    remote_repos_path: pathlib.Path,
+) -> None:
+    """Verify each test gets its own copy of git_repo."""
+    # Create a file in this repo
+    test_file = pathlib.Path(git_repo.path) / "test_isolation.txt"
+    test_file.write_text("test isolation")
+
+    # The master copy should NOT have this file
+    master_copy = remote_repos_path / "git_repo_master"
+    master_test_file = master_copy / "test_isolation.txt"
+    assert not master_test_file.exists(), "test changes should not affect master_copy"
+
+
+@pytest.mark.performance
+def test_fixture_timing_baseline(
+    git_repo: GitSync,
+    hg_repo: HgSync,
+    svn_repo: SvnSync,
+) -> None:
+    """Baseline test that uses all three repo fixtures.
+
+    This test helps establish timing baselines when running with
+    --fixture-durations.
+    """
+    assert pathlib.Path(git_repo.path).exists()
+    assert pathlib.Path(hg_repo.path).exists()
+    assert pathlib.Path(svn_repo.path).exists()
+
+
+# =============================================================================
+# Copy Method Benchmarks
+# =============================================================================
+# These benchmarks compare native VCS copy commands against shutil.copytree
+# to determine which method is faster for each VCS type.
+
+
+class CopyBenchmarkResult(t.NamedTuple):
+    """Result from a copy benchmark iteration."""
+
+    method: str
+    duration_ms: float
+
+
+def _benchmark_copy(
+    src: pathlib.Path,
+    dst_base: pathlib.Path,
+    copy_fn: t.Callable[[pathlib.Path, pathlib.Path], None],
+    iterations: int = 5,
+) -> list[float]:
+    """Run copy benchmark for multiple iterations, return durations in ms."""
+    import shutil
+    import time
+
+    durations: list[float] = []
+    for i in range(iterations):
+        dst = dst_base / f"iter_{i}"
+        if dst.exists():
+            shutil.rmtree(dst)
+
+        start = time.perf_counter()
+        copy_fn(src, dst)
+        duration_ms = (time.perf_counter() - start) * 1000
+        durations.append(duration_ms)
+
+        # Cleanup for next iteration
+        if dst.exists():
+            shutil.rmtree(dst)
+
+    return durations
+
+
+@pytest.mark.performance
+@pytest.mark.benchmark
+def test_benchmark_svn_copy_methods(
+    empty_svn_repo: pathlib.Path,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Benchmark svnadmin hotcopy vs shutil.copytree for SVN repos.
+
+    This test determines if svnadmin hotcopy is faster than shutil.copytree.
+    Results are printed to help decide which method to use in fixtures.
+    """
+    import shutil
+    import subprocess
+
+    def copytree_copy(src: pathlib.Path, dst: pathlib.Path) -> None:
+        shutil.copytree(src, dst)
+
+    def hotcopy_copy(src: pathlib.Path, dst: pathlib.Path) -> None:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["svnadmin", "hotcopy", str(src), str(dst)],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+
+    # Benchmark both methods
+    copytree_times = _benchmark_copy(
+        empty_svn_repo, tmp_path / "copytree", copytree_copy
+    )
+    hotcopy_times = _benchmark_copy(empty_svn_repo, tmp_path / "hotcopy", hotcopy_copy)
+
+    # Calculate statistics
+    copytree_avg = sum(copytree_times) / len(copytree_times)
+    copytree_min = min(copytree_times)
+    hotcopy_avg = sum(hotcopy_times) / len(hotcopy_times)
+    hotcopy_min = min(hotcopy_times)
+
+    # Report results
+    print("\n" + "=" * 60)
+    print("SVN Copy Method Benchmark Results")
+    print("=" * 60)
+    print(f"shutil.copytree: avg={copytree_avg:.2f}ms, min={copytree_min:.2f}ms")
+    print(f"svnadmin hotcopy: avg={hotcopy_avg:.2f}ms, min={hotcopy_min:.2f}ms")
+    print(f"Speedup: {copytree_avg / hotcopy_avg:.2f}x")
+    print(f"Winner: {'hotcopy' if hotcopy_avg < copytree_avg else 'copytree'}")
+    print("=" * 60)
+
+    # Store results for analysis (test always passes - it's informational)
+    # The assertion is informational - we want to see results regardless
+    assert True, (
+        f"SVN benchmark: copytree={copytree_avg:.2f}ms, hotcopy={hotcopy_avg:.2f}ms"
+    )
+
+
+@pytest.mark.performance
+@pytest.mark.benchmark
+def test_benchmark_git_copy_methods(
+    empty_git_repo: pathlib.Path,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Benchmark git clone --local vs shutil.copytree for Git repos.
+
+    Git's --local flag uses hardlinks when possible, which can be faster.
+    """
+    import shutil
+    import subprocess
+
+    def copytree_copy(src: pathlib.Path, dst: pathlib.Path) -> None:
+        shutil.copytree(src, dst)
+
+    def git_clone_local(src: pathlib.Path, dst: pathlib.Path) -> None:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "clone", "--local", str(src), str(dst)],
+            check=True,
+            capture_output=True,
+            timeout=30,
+        )
+
+    # Benchmark both methods
+    copytree_times = _benchmark_copy(
+        empty_git_repo, tmp_path / "copytree", copytree_copy
+    )
+    clone_times = _benchmark_copy(empty_git_repo, tmp_path / "clone", git_clone_local)
+
+    # Calculate statistics
+    copytree_avg = sum(copytree_times) / len(copytree_times)
+    copytree_min = min(copytree_times)
+    clone_avg = sum(clone_times) / len(clone_times)
+    clone_min = min(clone_times)
+
+    # Report results
+    print("\n" + "=" * 60)
+    print("Git Copy Method Benchmark Results")
+    print("=" * 60)
+    print(f"shutil.copytree: avg={copytree_avg:.2f}ms, min={copytree_min:.2f}ms")
+    print(f"git clone --local: avg={clone_avg:.2f}ms, min={clone_min:.2f}ms")
+    print(f"Speedup: {copytree_avg / clone_avg:.2f}x")
+    print(f"Winner: {'clone' if clone_avg < copytree_avg else 'copytree'}")
+    print("=" * 60)
+
+    assert True, (
+        f"Git benchmark: copytree={copytree_avg:.2f}ms, clone={clone_avg:.2f}ms"
+    )
+
+
+@pytest.mark.performance
+@pytest.mark.benchmark
+def test_benchmark_hg_copy_methods(
+    empty_hg_repo: pathlib.Path,
+    tmp_path: pathlib.Path,
+    hgconfig: pathlib.Path,
+) -> None:
+    """Benchmark hg clone vs shutil.copytree for Mercurial repos.
+
+    Mercurial's clone can use hardlinks with --pull, but hg is inherently slow.
+    """
+    import os
+    import shutil
+    import subprocess
+
+    env = {**os.environ, "HGRCPATH": str(hgconfig)}
+
+    def copytree_copy(src: pathlib.Path, dst: pathlib.Path) -> None:
+        shutil.copytree(src, dst)
+
+    def hg_clone(src: pathlib.Path, dst: pathlib.Path) -> None:
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["hg", "clone", str(src), str(dst)],
+            check=True,
+            capture_output=True,
+            timeout=60,
+            env=env,
+        )
+
+    # Benchmark both methods
+    copytree_times = _benchmark_copy(
+        empty_hg_repo, tmp_path / "copytree", copytree_copy
+    )
+    clone_times = _benchmark_copy(empty_hg_repo, tmp_path / "clone", hg_clone)
+
+    # Calculate statistics
+    copytree_avg = sum(copytree_times) / len(copytree_times)
+    copytree_min = min(copytree_times)
+    clone_avg = sum(clone_times) / len(clone_times)
+    clone_min = min(clone_times)
+
+    # Report results
+    print("\n" + "=" * 60)
+    print("Mercurial Copy Method Benchmark Results")
+    print("=" * 60)
+    print(f"shutil.copytree: avg={copytree_avg:.2f}ms, min={copytree_min:.2f}ms")
+    print(f"hg clone: avg={clone_avg:.2f}ms, min={clone_min:.2f}ms")
+    print(f"Speedup: {copytree_avg / clone_avg:.2f}x")
+    print(f"Winner: {'clone' if clone_avg < copytree_avg else 'copytree'}")
+    print("=" * 60)
+
+    assert True, f"Hg benchmark: copytree={copytree_avg:.2f}ms, clone={clone_avg:.2f}ms"
+
+
+@pytest.mark.performance
+@pytest.mark.benchmark
+def test_benchmark_summary(
+    empty_git_repo: pathlib.Path,
+    empty_svn_repo: pathlib.Path,
+    empty_hg_repo: pathlib.Path,
+    tmp_path: pathlib.Path,
+    hgconfig: pathlib.Path,
+) -> None:
+    """Comprehensive benchmark summary comparing all VCS copy methods.
+
+    This test provides a single-run summary of all copy methods for quick
+    comparison. Run with: pytest -v -s -m benchmark --run-performance
+    """
+    import os
+    import shutil
+    import subprocess
+    import time
+
+    env = {**os.environ, "HGRCPATH": str(hgconfig)}
+
+    def measure_once(
+        name: str,
+        src: pathlib.Path,
+        dst: pathlib.Path,
+        copy_fn: t.Callable[[], t.Any],
+    ) -> float:
+        if dst.exists():
+            shutil.rmtree(dst)
+        start = time.perf_counter()
+        copy_fn()
+        duration = (time.perf_counter() - start) * 1000
+        if dst.exists():
+            shutil.rmtree(dst)
+        return duration
+
+    results: dict[str, dict[str, float]] = {}
+
+    # SVN benchmarks
+    svn_copytree_dst = tmp_path / "svn_copytree"
+    svn_hotcopy_dst = tmp_path / "svn_hotcopy"
+    results["SVN"] = {
+        "copytree": measure_once(
+            "svn_copytree",
+            empty_svn_repo,
+            svn_copytree_dst,
+            lambda: shutil.copytree(empty_svn_repo, svn_copytree_dst),
+        ),
+        "native": measure_once(
+            "svn_hotcopy",
+            empty_svn_repo,
+            svn_hotcopy_dst,
+            lambda: subprocess.run(
+                ["svnadmin", "hotcopy", str(empty_svn_repo), str(svn_hotcopy_dst)],
+                check=True,
+                capture_output=True,
+            ),
+        ),
+    }
+
+    # Git benchmarks
+    git_copytree_dst = tmp_path / "git_copytree"
+    git_clone_dst = tmp_path / "git_clone"
+    results["Git"] = {
+        "copytree": measure_once(
+            "git_copytree",
+            empty_git_repo,
+            git_copytree_dst,
+            lambda: shutil.copytree(empty_git_repo, git_copytree_dst),
+        ),
+        "native": measure_once(
+            "git_clone",
+            empty_git_repo,
+            git_clone_dst,
+            lambda: subprocess.run(
+                ["git", "clone", "--local", str(empty_git_repo), str(git_clone_dst)],
+                check=True,
+                capture_output=True,
+            ),
+        ),
+    }
+
+    # Hg benchmarks
+    hg_copytree_dst = tmp_path / "hg_copytree"
+    hg_clone_dst = tmp_path / "hg_clone"
+    results["Hg"] = {
+        "copytree": measure_once(
+            "hg_copytree",
+            empty_hg_repo,
+            hg_copytree_dst,
+            lambda: shutil.copytree(empty_hg_repo, hg_copytree_dst),
+        ),
+        "native": measure_once(
+            "hg_clone",
+            empty_hg_repo,
+            hg_clone_dst,
+            lambda: subprocess.run(
+                ["hg", "clone", str(empty_hg_repo), str(hg_clone_dst)],
+                check=True,
+                capture_output=True,
+                env=env,
+            ),
+        ),
+    }
+
+    # Print summary
+    print("\n" + "=" * 70)
+    print("VCS Copy Method Benchmark Summary")
+    print("=" * 70)
+    print(
+        f"{'VCS':<6} {'copytree (ms)':<15} {'native (ms)':<15} "
+        f"{'speedup':<10} {'winner'}"
+    )
+    print("-" * 70)
+    for vcs, times in results.items():
+        speedup = times["copytree"] / times["native"]
+        winner = "native" if times["native"] < times["copytree"] else "copytree"
+        print(
+            f"{vcs:<6} {times['copytree']:<15.2f} {times['native']:<15.2f} "
+            f"{speedup:<10.2f}x {winner}"
+        )
+    print("=" * 70)
+    print("\nRecommendations:")
+    for vcs, times in results.items():
+        if times["native"] < times["copytree"]:
+            print(
+                f"  - {vcs}: Use native copy (svnadmin hotcopy / git clone / hg clone)"
+            )
+        else:
+            print(f"  - {vcs}: Use shutil.copytree")
+    print("=" * 70)

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -365,7 +374,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -585,6 +594,7 @@ dev = [
     { name = "gp-sphinx" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
@@ -610,6 +620,7 @@ lint = [
 testing = [
     { name = "gp-libs" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
@@ -631,6 +642,7 @@ dev = [
     { name = "gp-sphinx", specifier = "==0.0.1a10" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
@@ -654,6 +666,7 @@ lint = [
 testing = [
     { name = "gp-libs" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
@@ -969,6 +982,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add XDG-based persistent cache for pytest fixtures (`~/.cache/libvcs/pytest/`)
- Add `RepoFixtureResult` with cache hit/miss tracking
- Add `atomic_init` for race-free initialization with pytest-xdist
- Include `FileLock` module for atomic operations

## Test plan
- [x] Unit tests for FileLock
- [x] Fixture performance benchmarks
- [x] Cache hit/miss tracking verification