### PR TITLE
feat: Add async/await support for VCS operations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -468,6 +468,139 @@ Bad:
 $ pipx install --suffix=@next --pip-args '\--pre' --force 'libvcs'
 ```
 
+## Asyncio Development
+
+### Architecture
+
+libvcs async support is organized in `_async/` subpackages:
+
+```
+libvcs/
+├── _internal/
+│   ├── subprocess.py         # Sync subprocess wrapper
+│   └── async_subprocess.py   # Async subprocess wrapper
+├── cmd/
+│   ├── git.py                # Git (sync)
+│   └── _async/git.py         # AsyncGit
+├── sync/
+│   ├── git.py                # GitSync (sync)
+│   └── _async/git.py         # AsyncGitSync
+```
+
+### Async Subprocess Patterns
+
+**Always use `communicate()` for subprocess I/O:**
+```python
+proc = await asyncio.create_subprocess_shell(...)
+stdout, stderr = await proc.communicate()  # Prevents deadlocks
+```
+
+**Use `asyncio.timeout()` for timeouts:**
+```python
+async with asyncio.timeout(300):
+    stdout, stderr = await proc.communicate()
+```
+
+**Handle BrokenPipeError gracefully:**
+```python
+try:
+    proc.stdin.write(data)
+    await proc.stdin.drain()
+except BrokenPipeError:
+    pass  # Process already exited - expected behavior
+```
+
+### Async API Conventions
+
+- **Class naming**: Use `Async` prefix: `AsyncGit`, `AsyncGitSync`
+- **Callbacks**: Async APIs accept only async callbacks (no union types)
+- **Shared logic**: Extract argument-building to sync functions, share with async
+
+```python
+# Shared argument building (sync)
+def build_clone_args(url: str, depth: int | None = None) -> list[str]:
+    args = ["clone", url]
+    if depth:
+        args.extend(["--depth", str(depth)])
+    return args
+
+# Async method uses shared logic
+async def clone(self, url: str, depth: int | None = None) -> str:
+    args = build_clone_args(url, depth)
+    return await self.run(args)
+```
+
+### Async Testing
+
+**pytest configuration:**
+```toml
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
+```
+
+**Async fixture pattern:**
+```python
+@pytest_asyncio.fixture(loop_scope="function")
+async def async_git_repo(tmp_path: Path) -> t.AsyncGenerator[AsyncGitSync, None]:
+    repo = AsyncGitSync(url="...", path=tmp_path / "repo")
+    await repo.obtain()
+    yield repo
+```
+
+**Parametrized async tests:**
+```python
+class CloneFixture(t.NamedTuple):
+    test_id: str
+    clone_kwargs: dict[str, t.Any]
+    expected: list[str]
+
+CLONE_FIXTURES = [
+    CloneFixture("basic", {}, [".git"]),
+    CloneFixture("shallow", {"depth": 1}, [".git"]),
+]
+
+@pytest.mark.parametrize(
+    list(CloneFixture._fields),
+    CLONE_FIXTURES,
+    ids=[f.test_id for f in CLONE_FIXTURES],
+)
+@pytest.mark.asyncio
+async def test_clone(test_id: str, clone_kwargs: dict, expected: list) -> None:
+    ...
+```
+
+### Async Anti-Patterns
+
+**DON'T poll returncode:**
+```python
+# WRONG
+while proc.returncode is None:
+    await asyncio.sleep(0.1)
+
+# RIGHT
+await proc.wait()
+```
+
+**DON'T mix blocking calls in async code:**
+```python
+# WRONG
+async def bad():
+    subprocess.run(["git", "clone", url])  # Blocks event loop!
+
+# RIGHT
+async def good():
+    proc = await asyncio.create_subprocess_shell(...)
+    await proc.wait()
+```
+
+**DON'T close the event loop in tests:**
+```python
+# WRONG - breaks pytest-asyncio cleanup
+loop = asyncio.get_running_loop()
+loop.close()
+```
+
 ## Debugging Tips
 
 When stuck in debugging loops:

--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,50 @@ $ uv add libvcs --prerelease allow
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### New features
+
+#### Async support (#504)
+
+Add async equivalents for all synchronous APIs, enabling non-blocking VCS operations:
+
+**Command classes** (`libvcs.cmd._async`):
+
+- {class}`~libvcs.cmd._async.git.AsyncGit` - async git commands
+- {class}`~libvcs.cmd._async.hg.AsyncHg` - async mercurial commands
+- {class}`~libvcs.cmd._async.svn.AsyncSvn` - async subversion commands
+
+**Sync classes** (`libvcs.sync._async`):
+
+- {class}`~libvcs.sync._async.git.AsyncGitSync` - async git repository management
+- {class}`~libvcs.sync._async.hg.AsyncHgSync` - async mercurial repository management
+- {class}`~libvcs.sync._async.svn.AsyncSvnSync` - async subversion repository management
+
+**Internal utilities**:
+
+- {func}`~libvcs._internal.async_run.async_run` - async command execution with progress callbacks
+- {class}`~libvcs._internal.async_subprocess.AsyncSubprocessCommand` - async subprocess wrapper
+
+Example usage:
+
+```python
+import asyncio
+from libvcs.sync._async.git import AsyncGitSync
+
+async def main():
+    repo = AsyncGitSync(url="https://github.com/user/repo", path="/tmp/repo")
+    await repo.obtain()  # Clone
+    await repo.update_repo()  # Pull
+
+asyncio.run(main())
+```
+
+### pytest plugin
+
+#### pytest_plugin: Add async fixtures (#504)
+
+- Add `async_git_repo`, `async_hg_repo`, `async_svn_repo` fixtures
+- Add `asyncio` to `doctest_namespace` for async doctests
+
 ## libvcs 0.40.0 (2026-04-25)
 
 ### What's new

--- a/README.md
+++ b/README.md
@@ -153,6 +153,46 @@ def test_my_git_tool(
     assert (checkout_path / ".git").is_dir()
 ```
 
+### 5. Async Support
+Run VCS operations asynchronously for better concurrency when managing multiple repositories.
+
+[**Learn more about Async Support**](https://libvcs.git-pull.com/topics/asyncio.html)
+
+```python
+import asyncio
+import pathlib
+from libvcs.sync._async.git import AsyncGitSync
+
+async def main():
+    repo = AsyncGitSync(
+        url="https://github.com/vcs-python/libvcs",
+        path=pathlib.Path.cwd() / "libvcs",
+    )
+    await repo.obtain()
+    await repo.update_repo()
+
+asyncio.run(main())
+```
+
+Clone multiple repositories concurrently:
+
+```python
+import asyncio
+from libvcs.sync._async.git import AsyncGitSync
+
+async def clone_all(repos: list[tuple[str, str]]):
+    tasks = [
+        AsyncGitSync(url=url, path=path).obtain()
+        for url, path in repos
+    ]
+    await asyncio.gather(*tasks)  # All clone in parallel
+
+asyncio.run(clone_all([
+    ("https://github.com/vcs-python/libvcs", "./libvcs"),
+    ("https://github.com/vcs-python/vcspull", "./vcspull"),
+]))
+```
+
 ## Project Information
 
 - **Python Support**: 3.10+

--- a/docs/api/pytest-plugin.md
+++ b/docs/api/pytest-plugin.md
@@ -42,6 +42,64 @@ def setup(
 ```
 :::
 
+## Async Fixtures
+
+For async testing with [pytest-asyncio], libvcs provides async fixture variants:
+
+[pytest-asyncio]: https://pytest-asyncio.readthedocs.io/
+
+### Configuration
+
+Add pytest-asyncio to your test dependencies and configure strict mode:
+
+```toml
+# pyproject.toml
+[tool.pytest.ini_options]
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
+```
+
+### Available Async Fixtures
+
+- {func}`async_git_repo` - An {class}`~libvcs.sync._async.git.AsyncGitSync` instance ready for testing
+- `async_create_git_remote_repo` - Factory to create temporary git repositories
+
+### Usage Example
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_async_repo_operations(async_git_repo):
+    """Test async repository operations."""
+    # async_git_repo is an AsyncGitSync instance
+    status = await async_git_repo.cmd.status()
+    assert 'On branch' in status
+
+    # Update the repo
+    await async_git_repo.update_repo()
+```
+
+### Creating Repositories in Async Tests
+
+```python
+import pytest
+from libvcs.sync._async.git import AsyncGitSync
+
+@pytest.mark.asyncio
+async def test_clone_repo(tmp_path, create_git_remote_repo):
+    """Test cloning a repository asynchronously."""
+    remote = create_git_remote_repo()
+    repo = AsyncGitSync(
+        url=f'file://{remote}',
+        path=tmp_path / 'clone',
+    )
+    await repo.obtain()
+    assert (tmp_path / 'clone' / '.git').exists()
+```
+
+See {doc}`/topics/asyncio` for more async patterns.
+
 ## Types
 
 ```{eval-rst}

--- a/docs/cmd/index.md
+++ b/docs/cmd/index.md
@@ -21,6 +21,16 @@ The `libvcs.cmd` module provides Python wrappers for VCS command-line tools:
 - {mod}`libvcs.cmd.hg` - Mercurial commands
 - {mod}`libvcs.cmd.svn` - Subversion commands
 
+### Async Variants
+
+Async equivalents are available in `libvcs.cmd._async`:
+
+- {class}`~libvcs.cmd._async.git.AsyncGit` - Async git commands
+- {class}`~libvcs.cmd._async.hg.AsyncHg` - Async mercurial commands
+- {class}`~libvcs.cmd._async.svn.AsyncSvn` - Async subversion commands
+
+See {doc}`/topics/asyncio` for usage patterns.
+
 ### When to use `cmd` vs `sync`
 
 | Module | Use Case |

--- a/docs/internals/async_run.md
+++ b/docs/internals/async_run.md
@@ -1,0 +1,8 @@
+# async_run - `libvcs._internal.async_run`
+
+Async equivalent of {mod}`libvcs._internal.run`.
+
+```{eval-rst}
+.. automodule:: libvcs._internal.async_run
+   :members:
+```

--- a/docs/internals/async_subprocess.md
+++ b/docs/internals/async_subprocess.md
@@ -1,0 +1,8 @@
+# AsyncSubprocessCommand - `libvcs._internal.async_subprocess`
+
+Async equivalent of {mod}`libvcs._internal.subprocess`.
+
+```{eval-rst}
+.. automodule:: libvcs._internal.async_subprocess
+   :members:
+```

--- a/docs/internals/index.md
+++ b/docs/internals/index.md
@@ -63,6 +63,8 @@ types
 dataclasses
 query_list
 run
+async_run
 subprocess
+async_subprocess
 shortcuts
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -98,3 +98,41 @@ origin.prune()
 ```
 
 See {doc}`/cmd/git/index` for the full API reference.
+
+### Async Usage
+
+All APIs have async equivalents for non-blocking operations:
+
+```python
+import asyncio
+from libvcs.cmd._async.git import AsyncGit
+
+async def main():
+    git = AsyncGit(path='/path/to/repo')
+
+    # Non-blocking git operations
+    await git.run(['init'])
+    status = await git.status()
+    print(status)
+
+asyncio.run(main())
+```
+
+For repository synchronization:
+
+```python
+import asyncio
+from libvcs.sync._async.git import AsyncGitSync
+
+async def main():
+    repo = AsyncGitSync(
+        url='https://github.com/vcs-python/libvcs',
+        path='/tmp/libvcs',
+    )
+    await repo.obtain()  # Clone
+    await repo.update_repo()  # Update
+
+asyncio.run(main())
+```
+
+See {doc}`/topics/asyncio` for the complete async guide.

--- a/docs/sync/index.md
+++ b/docs/sync/index.md
@@ -14,6 +14,16 @@ versions.
 
 :::
 
+## Async Variants
+
+Async equivalents are available in `libvcs.sync._async`:
+
+- {class}`~libvcs.sync._async.git.AsyncGitSync` - Async git repository management
+- {class}`~libvcs.sync._async.hg.AsyncHgSync` - Async mercurial repository management
+- {class}`~libvcs.sync._async.svn.AsyncSvnSync` - Async subversion repository management
+
+See {doc}`/topics/asyncio` for usage patterns.
+
 ## Modules
 
 ::::{grid} 1 1 2 2

--- a/docs/topics/asyncio.md
+++ b/docs/topics/asyncio.md
@@ -1,0 +1,226 @@
+(asyncio)=
+
+# Async Support
+
+libvcs provides **async equivalents** for all synchronous APIs, enabling
+non-blocking VCS operations ideal for managing multiple repositories
+concurrently.
+
+## Overview
+
+The async API mirrors the sync API with an `Async` prefix:
+
+| Sync Class | Async Equivalent |
+|------------|------------------|
+| {class}`~libvcs.cmd.git.Git` | {class}`~libvcs.cmd._async.git.AsyncGit` |
+| {class}`~libvcs.cmd.hg.Hg` | {class}`~libvcs.cmd._async.hg.AsyncHg` |
+| {class}`~libvcs.cmd.svn.Svn` | {class}`~libvcs.cmd._async.svn.AsyncSvn` |
+| {class}`~libvcs.sync.git.GitSync` | {class}`~libvcs.sync._async.git.AsyncGitSync` |
+| {class}`~libvcs.sync.hg.HgSync` | {class}`~libvcs.sync._async.hg.AsyncHgSync` |
+| {class}`~libvcs.sync.svn.SvnSync` | {class}`~libvcs.sync._async.svn.AsyncSvnSync` |
+
+## Why Async?
+
+Async APIs excel when:
+
+- **Managing multiple repositories** - Clone/update repos concurrently
+- **Building responsive applications** - UI remains responsive during VCS operations
+- **Integration with async frameworks** - FastAPI, aiohttp, etc.
+- **CI/CD pipelines** - Parallel repository operations
+
+## Basic Usage
+
+### Running Git Commands
+
+```python
+>>> from libvcs.cmd._async.git import AsyncGit
+>>> async def example():
+...     git = AsyncGit(path=tmp_path)
+...     await git.run(['init'])
+...     status = await git.status()
+...     return 'On branch' in status
+>>> asyncio.run(example())
+True
+```
+
+### Cloning a Repository
+
+```python
+>>> from libvcs.cmd._async.git import AsyncGit
+>>> async def clone_example():
+...     repo_path = tmp_path / 'myrepo'
+...     git = AsyncGit(path=repo_path)
+...     url = f'file://{create_git_remote_repo()}'
+...     await git.clone(url=url)
+...     return (repo_path / '.git').exists()
+>>> asyncio.run(clone_example())
+True
+```
+
+### Repository Synchronization
+
+For higher-level repository management, use the sync classes:
+
+```python
+>>> from libvcs.sync._async.git import AsyncGitSync
+>>> async def sync_example():
+...     url = f'file://{create_git_remote_repo()}'
+...     repo_path = tmp_path / 'synced_repo'
+...     repo = AsyncGitSync(url=url, path=repo_path)
+...     await repo.obtain()  # Clone
+...     await repo.update_repo()  # Pull updates
+...     return (repo_path / '.git').exists()
+>>> asyncio.run(sync_example())
+True
+```
+
+## Concurrent Operations
+
+The primary advantage of async is running operations concurrently:
+
+```python
+>>> from libvcs.sync._async.git import AsyncGitSync
+>>> async def concurrent_clone():
+...     urls = [
+...         f'file://{create_git_remote_repo()}',
+...         f'file://{create_git_remote_repo()}',
+...     ]
+...     tasks = []
+...     for i, url in enumerate(urls):
+...         repo = AsyncGitSync(url=url, path=tmp_path / f'repo_{i}')
+...         tasks.append(repo.obtain())
+...     await asyncio.gather(*tasks)  # Clone all concurrently
+...     return all((tmp_path / f'repo_{i}' / '.git').exists() for i in range(2))
+>>> asyncio.run(concurrent_clone())
+True
+```
+
+## Progress Callbacks
+
+Async APIs support async progress callbacks for real-time output streaming:
+
+```python
+>>> import datetime
+>>> from libvcs._internal.async_run import async_run
+>>> async def with_progress():
+...     output_lines = []
+...     async def progress(output: str, timestamp: datetime.datetime) -> None:
+...         output_lines.append(output)
+...     result = await async_run(['echo', 'hello'], callback=progress)
+...     return result.strip()
+>>> asyncio.run(with_progress())
+'hello'
+```
+
+For sync callbacks, use the wrapper:
+
+```python
+>>> from libvcs._internal.async_run import wrap_sync_callback
+>>> def my_sync_callback(output: str, timestamp: datetime.datetime) -> None:
+...     print(output, end='')
+>>> async_callback = wrap_sync_callback(my_sync_callback)
+```
+
+## Sync vs Async Comparison
+
+### Sync Pattern
+
+```python
+from libvcs.sync.git import GitSync
+
+repo = GitSync(url="https://github.com/user/repo", path="/tmp/repo")
+repo.obtain()  # Blocks until complete
+repo.update_repo()  # Blocks again
+```
+
+### Async Pattern
+
+```python
+import asyncio
+from libvcs.sync._async.git import AsyncGitSync
+
+async def main():
+    repo = AsyncGitSync(url="https://github.com/user/repo", path="/tmp/repo")
+    await repo.obtain()  # Non-blocking
+    await repo.update_repo()
+
+asyncio.run(main())
+```
+
+## Error Handling
+
+Async methods raise the same exceptions as sync equivalents:
+
+```python
+>>> from libvcs import exc
+>>> from libvcs._internal.async_run import async_run
+>>> async def error_example():
+...     try:
+...         await async_run(['git', 'nonexistent-command'], check_returncode=True)
+...     except exc.CommandError as e:
+...         return 'error caught'
+...     return 'no error'
+>>> asyncio.run(error_example())
+'error caught'
+```
+
+### Timeout Handling
+
+```python
+>>> from libvcs import exc
+>>> from libvcs._internal.async_run import async_run
+>>> async def timeout_example():
+...     try:
+...         # Very short timeout for demo
+...         await async_run(['sleep', '10'], timeout=0.1)
+...     except exc.CommandTimeoutError:
+...         return 'timeout caught'
+...     return 'completed'
+>>> asyncio.run(timeout_example())
+'timeout caught'
+```
+
+## Testing with pytest-asyncio
+
+Use the async fixtures for testing:
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_repo_operations(async_git_repo):
+    # async_git_repo is an AsyncGitSync instance
+    status = await async_git_repo.cmd.status()
+    assert 'On branch' in status
+```
+
+See {doc}`/pytest-plugin` for available async fixtures.
+
+## When to Use Async
+
+| Scenario | Recommendation |
+|----------|----------------|
+| Single repository, simple script | Sync API (simpler) |
+| Multiple repositories concurrently | **Async API** |
+| Integration with async framework | **Async API** |
+| CI/CD with parallel operations | **Async API** |
+| Interactive CLI tool | Either (prefer sync for simplicity) |
+
+## API Reference
+
+### Command Classes
+
+- {class}`~libvcs.cmd._async.git.AsyncGit` - Async git commands
+- {class}`~libvcs.cmd._async.hg.AsyncHg` - Async mercurial commands
+- {class}`~libvcs.cmd._async.svn.AsyncSvn` - Async subversion commands
+
+### Sync Classes
+
+- {class}`~libvcs.sync._async.git.AsyncGitSync` - Async git repository management
+- {class}`~libvcs.sync._async.hg.AsyncHgSync` - Async mercurial repository management
+- {class}`~libvcs.sync._async.svn.AsyncSvnSync` - Async subversion repository management
+
+### Internal Utilities
+
+- {func}`~libvcs._internal.async_run.async_run` - Low-level async command execution
+- {class}`~libvcs._internal.async_subprocess.AsyncSubprocessCommand` - Async subprocess wrapper

--- a/docs/topics/index.md
+++ b/docs/topics/index.md
@@ -29,6 +29,7 @@ Detect, validate, and normalize VCS URLs.
 ```{toctree}
 :hidden:
 
+asyncio
 traversing_git
 filtering
 url_parsing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,10 @@ testpaths = [
 ]
 filterwarnings = [
   "ignore:The frontend.Option(Parser)? class.*:DeprecationWarning::",
+  "ignore:The configuration option \"asyncio_default_fixture_loop_scope\" is unset.:DeprecationWarning:pytest_asyncio.plugin",
 ]
+asyncio_mode = "strict"
+asyncio_default_fixture_loop_scope = "function"
 
 [tool.pytest-watcher]
 now = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dev = [
   # Testing
   "gp-libs",
   "pytest",
+  "pytest-asyncio",
   "pytest-rerunfailures",
   "pytest-mock",
   "pytest-watcher",
@@ -94,6 +95,7 @@ docs = [
 testing = [
   "gp-libs",
   "pytest",
+  "pytest-asyncio",
   "pytest-rerunfailures",
   "pytest-mock",
   "pytest-watcher",

--- a/src/libvcs/_internal/async_run.py
+++ b/src/libvcs/_internal/async_run.py
@@ -1,0 +1,300 @@
+"""Async subprocess execution with progress callbacks.
+
+Async equivalent of :mod:`libvcs._internal.run`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+
+Examples
+--------
+- :func:`~async_run`: Async command execution with progress callback.
+
+  Before (sync):
+
+  >>> from libvcs._internal.run import run
+  >>> output = run(['echo', 'hello'], check_returncode=True)
+
+  With this (async):
+
+  >>> from libvcs._internal.async_run import async_run
+  >>> async def example():
+  ...     output = await async_run(['echo', 'hello'])
+  ...     return output.strip()
+  >>> asyncio.run(example())
+  'hello'
+"""
+
+from __future__ import annotations
+
+import asyncio
+import asyncio.subprocess
+import datetime
+import logging
+import sys
+import typing as t
+from collections.abc import Mapping, Sequence
+
+from libvcs import exc
+from libvcs._internal.types import StrOrBytesPath
+
+from .run import console_to_str
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncProgressCallbackProtocol(t.Protocol):
+    """Async callback to report subprocess communication.
+
+    Async equivalent of :class:`~libvcs._internal.run.ProgressCallbackProtocol`.
+
+    Examples
+    --------
+    >>> async def my_progress(output: str, timestamp: datetime.datetime) -> None:
+    ...     print(f"[{timestamp}] {output}", end="")
+
+    See Also
+    --------
+    libvcs._internal.run.ProgressCallbackProtocol : Sync equivalent
+    wrap_sync_callback : Helper to wrap sync callbacks for async use
+    """
+
+    async def __call__(self, output: str, timestamp: datetime.datetime) -> None:
+        """Process progress for subprocess communication."""
+        ...
+
+
+def wrap_sync_callback(
+    sync_cb: t.Callable[[str, datetime.datetime], None],
+) -> AsyncProgressCallbackProtocol:
+    """Wrap a sync callback for use with async APIs.
+
+    This helper allows users with existing sync callbacks to use them
+    with async APIs without modification.
+
+    Parameters
+    ----------
+    sync_cb : Callable[[str, datetime.datetime], None]
+        Synchronous callback function
+
+    Returns
+    -------
+    AsyncProgressCallbackProtocol
+        Async wrapper that calls the sync callback
+
+    Examples
+    --------
+    >>> def my_sync_progress(output: str, timestamp: datetime.datetime) -> None:
+    ...     print(output, end="")
+    >>> async_cb = wrap_sync_callback(my_sync_progress)
+    >>> # Now use async_cb with async_run()
+    """
+
+    async def wrapper(output: str, timestamp: datetime.datetime) -> None:
+        sync_cb(output, timestamp)
+
+    return wrapper
+
+
+if sys.platform == "win32":
+    _ENV: t.TypeAlias = Mapping[str, str]
+else:
+    _ENV: t.TypeAlias = Mapping[bytes, StrOrBytesPath] | Mapping[str, StrOrBytesPath]
+
+_CMD: t.TypeAlias = StrOrBytesPath | Sequence[StrOrBytesPath]
+
+
+def _args_to_list(args: _CMD) -> list[str]:
+    """Convert command args to list of strings.
+
+    Parameters
+    ----------
+    args : str | bytes | Path | Sequence[str | bytes | Path]
+        Command arguments in various forms
+
+    Returns
+    -------
+    list[str]
+        Normalized list of string arguments
+    """
+    from os import PathLike
+
+    if isinstance(args, (str, bytes, PathLike)):
+        if isinstance(args, bytes):
+            return [args.decode()]
+        return [str(args)]
+    return [arg.decode() if isinstance(arg, bytes) else str(arg) for arg in args]
+
+
+async def async_run(
+    args: _CMD,
+    *,
+    cwd: StrOrBytesPath | None = None,
+    env: _ENV | None = None,
+    check_returncode: bool = True,
+    callback: AsyncProgressCallbackProtocol | None = None,
+    timeout: float | None = None,
+) -> str:
+    """Run a command asynchronously.
+
+    Run 'args' and return stdout content (non-blocking). Optionally stream
+    stderr to a callback for progress reporting. Raises an exception if
+    the command exits non-zero (when check_returncode=True).
+
+    This is the async equivalent of :func:`~libvcs._internal.run.run`.
+
+    Parameters
+    ----------
+    args : list[str] | str
+        The command to run
+    cwd : str | Path, optional
+        Working directory for the command
+    env : Mapping[str, str], optional
+        Environment variables for the command
+    check_returncode : bool, default True
+        If True, raise :class:`~libvcs.exc.CommandError` on non-zero exit
+    callback : AsyncProgressCallbackProtocol, optional
+        Async callback to receive stderr output in real-time.
+        Signature: ``async def callback(output: str, timestamp: datetime) -> None``
+    timeout : float, optional
+        Timeout in seconds. Raises :class:`~libvcs.exc.CommandTimeoutError`
+        if exceeded.
+
+    Returns
+    -------
+    str
+        Combined stdout output
+
+    Raises
+    ------
+    libvcs.exc.CommandError
+        If check_returncode=True and process exits with non-zero code
+    libvcs.exc.CommandTimeoutError
+        If timeout is exceeded
+
+    Examples
+    --------
+    Basic usage:
+
+    >>> async def example():
+    ...     output = await async_run(['echo', 'hello'])
+    ...     return output.strip()
+    >>> asyncio.run(example())
+    'hello'
+
+    With progress callback:
+
+    >>> async def progress(output: str, timestamp: datetime.datetime) -> None:
+    ...     pass  # Handle progress output
+    >>> async def clone_example():
+    ...     url = f'file://{create_git_remote_repo()}'
+    ...     output = await async_run(['git', 'clone', url, str(tmp_path / 'cb_repo')])
+    ...     return 'Cloning' in output or output == ''
+    >>> asyncio.run(clone_example())
+    True
+
+    See Also
+    --------
+    libvcs._internal.run.run : Synchronous equivalent
+    AsyncSubprocessCommand : Lower-level async subprocess wrapper
+    """
+    args_list = _args_to_list(args)
+
+    # Create subprocess with pipes (using non-shell exec for security)
+    proc = await asyncio.subprocess.create_subprocess_exec(
+        *args_list,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=cwd,
+        env=env,
+    )
+
+    async def _run_with_callback() -> tuple[bytes, bytes, int]:
+        """Run subprocess, streaming stderr to callback."""
+        stdout_data = b""
+        stderr_data = b""
+
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+
+        # Read stderr line-by-line for progress callback
+        if callback is not None:
+            # Stream stderr to callback while collecting stdout
+            async def read_stderr() -> bytes:
+                collected = b""
+                assert proc.stderr is not None
+                while True:
+                    line = await proc.stderr.readline()
+                    if not line:
+                        break
+                    collected += line
+                    # Call progress callback with decoded line
+                    await callback(
+                        output=console_to_str(line),
+                        timestamp=datetime.datetime.now(),
+                    )
+                return collected
+
+            # Run stdout collection and stderr streaming concurrently
+            stdout_task = asyncio.create_task(proc.stdout.read())
+            stderr_task = asyncio.create_task(read_stderr())
+
+            stdout_data, stderr_data = await asyncio.gather(stdout_task, stderr_task)
+
+            # Send final carriage return (matching sync behavior)
+            await callback(output="\r", timestamp=datetime.datetime.now())
+        else:
+            # No callback - just collect both streams
+            stdout_data, stderr_data = await proc.communicate()
+
+        # Wait for process to complete
+        await proc.wait()
+        returncode = proc.returncode
+        assert returncode is not None
+
+        return stdout_data, stderr_data, returncode
+
+    try:
+        if timeout is not None:
+            stdout_bytes, stderr_bytes, returncode = await asyncio.wait_for(
+                _run_with_callback(),
+                timeout=timeout,
+            )
+        else:
+            stdout_bytes, stderr_bytes, returncode = await _run_with_callback()
+    except asyncio.TimeoutError:
+        # Kill process on timeout
+        proc.kill()
+        await proc.wait()
+        raise exc.CommandTimeoutError(
+            output="Command timed out",
+            returncode=-1,
+            cmd=args_list,
+        ) from None
+
+    # Process stdout: strip and join lines (matching sync behavior)
+    if stdout_bytes:
+        lines = filter(
+            None,
+            (line.strip() for line in stdout_bytes.splitlines()),
+        )
+        output = console_to_str(b"\n".join(lines))
+    else:
+        output = ""
+
+    # On error, use stderr content
+    if returncode != 0 and stderr_bytes:
+        stderr_lines = filter(
+            None,
+            (line.strip() for line in stderr_bytes.splitlines()),
+        )
+        output = console_to_str(b"".join(stderr_lines))
+
+    if returncode != 0 and check_returncode:
+        raise exc.CommandError(
+            output=output,
+            returncode=returncode,
+            cmd=args_list,
+        )
+
+    return output

--- a/src/libvcs/_internal/async_subprocess.py
+++ b/src/libvcs/_internal/async_subprocess.py
@@ -1,0 +1,393 @@
+# ruff: noqa: A002
+r"""Async invocable :mod:`subprocess` wrapper.
+
+Async equivalent of :mod:`libvcs._internal.subprocess`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+
+Examples
+--------
+- :class:`~AsyncSubprocessCommand`: Async wrapper for subprocess execution.
+
+  Before (sync):
+
+  >>> import subprocess
+  >>> subprocess.run(
+  ...    ['echo', 'hi'],
+  ...    capture_output=True, text=True
+  ... ).stdout
+  'hi\n'
+
+  With this (async):
+
+  >>> async def example():
+  ...     cmd = AsyncSubprocessCommand(['echo', 'hi'])
+  ...     result = await cmd.run()
+  ...     return result.stdout
+  >>> asyncio.run(example())
+  b'hi\n'
+"""
+
+from __future__ import annotations
+
+import asyncio
+import asyncio.subprocess
+import dataclasses
+import subprocess
+import typing as t
+from collections.abc import Mapping, Sequence
+
+from libvcs._internal.types import StrOrBytesPath
+
+from .dataclasses import SkipDefaultFieldsReprMixin
+
+#: Command type alias
+_CMD: t.TypeAlias = StrOrBytesPath | Sequence[StrOrBytesPath]
+
+#: Environment type alias
+_ENV: t.TypeAlias = Mapping[str, str]
+
+
+@dataclasses.dataclass
+class AsyncCompletedProcess(t.Generic[t.AnyStr]):
+    """Result of an async subprocess execution.
+
+    Mirrors :class:`subprocess.CompletedProcess` for async context.
+
+    Parameters
+    ----------
+    args : list[str]
+        The command arguments
+    returncode : int
+        Exit code of the process
+    stdout : str | bytes | None
+        Captured stdout, if any
+    stderr : str | bytes | None
+        Captured stderr, if any
+    """
+
+    args: list[str]
+    returncode: int
+    stdout: t.AnyStr | None = None
+    stderr: t.AnyStr | None = None
+
+    def check_returncode(self) -> None:
+        """Raise CalledProcessError if returncode is non-zero.
+
+        Raises
+        ------
+        subprocess.CalledProcessError
+            If the process exited with a non-zero code
+        """
+        if self.returncode != 0:
+            raise subprocess.CalledProcessError(
+                self.returncode,
+                self.args,
+                self.stdout,
+                self.stderr,
+            )
+
+
+@dataclasses.dataclass(repr=False)
+class AsyncSubprocessCommand(SkipDefaultFieldsReprMixin):
+    r"""Async subprocess command wrapper.
+
+    Wraps asyncio subprocess execution in a dataclass for inspection
+    and mutation before invocation.
+
+    Parameters
+    ----------
+    args : list[str]
+        Command and arguments to run
+    cwd : str | Path, optional
+        Working directory for the command
+    env : dict[str, str], optional
+        Environment variables for the command
+
+    Examples
+    --------
+    >>> import asyncio
+    >>> async def example():
+    ...     cmd = AsyncSubprocessCommand(['echo', 'hello'])
+    ...     result = await cmd.run()
+    ...     return result.stdout
+    >>> asyncio.run(example())
+    b'hello\n'
+
+    Modify before running:
+
+    >>> cmd = AsyncSubprocessCommand(['echo', 'hi'])
+    >>> cmd.args
+    ['echo', 'hi']
+    >>> cmd.args[1] = 'hello'
+    >>> cmd.args
+    ['echo', 'hello']
+    """
+
+    args: _CMD
+    cwd: StrOrBytesPath | None = None
+    env: _ENV | None = None
+
+    # Limits for stdout/stderr
+    limit: int = 2**16  # 64 KiB default buffer
+
+    def _args_as_list(self) -> list[str]:
+        """Convert args to list of strings for asyncio."""
+        from os import PathLike
+
+        args = self.args
+        if isinstance(args, (str, bytes, PathLike)):
+            # Single command (str, bytes, or PathLike)
+            return [str(args) if not isinstance(args, bytes) else args.decode()]
+        # At this point, args is Sequence[StrOrBytesPath]
+        return [
+            str(arg) if not isinstance(arg, bytes) else arg.decode() for arg in args
+        ]
+
+    async def _create_process(
+        self,
+        *,
+        stdin: int | None = None,
+        stdout: int | None = None,
+        stderr: int | None = None,
+    ) -> asyncio.subprocess.Process:
+        """Create an async subprocess.
+
+        Uses asyncio.create_subprocess_exec for secure, non-shell execution.
+        """
+        args_list = self._args_as_list()
+        # Use asyncio's subprocess creation (non-shell variant for security)
+        return await asyncio.subprocess.create_subprocess_exec(
+            *args_list,
+            stdin=stdin,
+            stdout=stdout,
+            stderr=stderr,
+            cwd=self.cwd,
+            env=self.env,
+            limit=self.limit,
+        )
+
+    @t.overload
+    async def run(
+        self,
+        *,
+        check: bool = ...,
+        timeout: float | None = ...,
+        input: bytes | None = ...,
+        text: t.Literal[False] = ...,
+    ) -> AsyncCompletedProcess[bytes]: ...
+
+    @t.overload
+    async def run(
+        self,
+        *,
+        check: bool = ...,
+        timeout: float | None = ...,
+        input: str | None = ...,
+        text: t.Literal[True],
+    ) -> AsyncCompletedProcess[str]: ...
+
+    @t.overload
+    async def run(
+        self,
+        *,
+        check: bool = ...,
+        timeout: float | None = ...,
+        input: str | bytes | None = ...,
+        text: bool = ...,
+    ) -> AsyncCompletedProcess[t.Any]: ...
+
+    async def run(
+        self,
+        *,
+        check: bool = False,
+        timeout: float | None = None,
+        input: str | bytes | None = None,
+        text: bool = False,
+    ) -> AsyncCompletedProcess[t.Any]:
+        r"""Run command asynchronously and return completed process.
+
+        Uses asyncio subprocess APIs for non-blocking operation.
+
+        Parameters
+        ----------
+        check : bool, default False
+            If True, raise CalledProcessError on non-zero exit
+        timeout : float, optional
+            Timeout in seconds. Raises asyncio.TimeoutError if exceeded.
+        input : str | bytes, optional
+            Data to send to stdin
+        text : bool, default False
+            If True, decode stdout/stderr as text
+
+        Returns
+        -------
+        AsyncCompletedProcess
+            Result with args, returncode, stdout, stderr
+
+        Raises
+        ------
+        subprocess.CalledProcessError
+            If check=True and process exits with non-zero code
+        asyncio.TimeoutError
+            If timeout is exceeded
+
+        Examples
+        --------
+        >>> import asyncio
+        >>> async def example():
+        ...     cmd = AsyncSubprocessCommand(['echo', 'hello'])
+        ...     result = await cmd.run(text=True)
+        ...     return result.stdout.strip()
+        >>> asyncio.run(example())
+        'hello'
+        """
+        args_list = self._args_as_list()
+
+        # Prepare input as bytes
+        input_bytes: bytes | None = None
+        if input is not None:
+            input_bytes = input.encode() if isinstance(input, str) else input
+
+        # Create subprocess
+        proc = await self._create_process(
+            stdin=asyncio.subprocess.PIPE if input_bytes else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        try:
+            # Use communicate() with optional timeout via wait_for
+            if timeout is not None:
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                    proc.communicate(input_bytes),
+                    timeout=timeout,
+                )
+            else:
+                stdout_bytes, stderr_bytes = await proc.communicate(input_bytes)
+        except asyncio.TimeoutError:
+            # Kill process on timeout
+            proc.kill()
+            await proc.wait()
+            raise
+
+        # Get return code (should be set after communicate)
+        returncode = proc.returncode
+        assert returncode is not None, "returncode should be set after communicate()"
+
+        # Decode if text mode
+        stdout: str | bytes | None = stdout_bytes
+        stderr: str | bytes | None = stderr_bytes
+        if text:
+            stdout = stdout_bytes.decode() if stdout_bytes else ""
+            stderr = stderr_bytes.decode() if stderr_bytes else ""
+
+        result: AsyncCompletedProcess[t.Any] = AsyncCompletedProcess(
+            args=args_list,
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+        if check:
+            result.check_returncode()
+
+        return result
+
+    async def check_output(
+        self,
+        *,
+        timeout: float | None = None,
+        input: str | bytes | None = None,
+        text: bool = False,
+    ) -> str | bytes:
+        r"""Run command and return stdout, raising on non-zero exit.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            Timeout in seconds
+        input : str | bytes, optional
+            Data to send to stdin
+        text : bool, default False
+            If True, return stdout as text
+
+        Returns
+        -------
+        str | bytes
+            Command stdout
+
+        Raises
+        ------
+        subprocess.CalledProcessError
+            If process exits with non-zero code
+        asyncio.TimeoutError
+            If timeout is exceeded
+
+        Examples
+        --------
+        >>> import asyncio
+        >>> async def example():
+        ...     cmd = AsyncSubprocessCommand(['echo', 'hello'])
+        ...     return await cmd.check_output(text=True)
+        >>> asyncio.run(example())
+        'hello\n'
+        """
+        result = await self.run(check=True, timeout=timeout, input=input, text=text)
+        return result.stdout if result.stdout is not None else (b"" if not text else "")
+
+    async def wait(
+        self,
+        *,
+        timeout: float | None = None,
+    ) -> int:
+        """Run command and return exit code.
+
+        Discards stdout/stderr.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        int
+            Process exit code
+
+        Raises
+        ------
+        asyncio.TimeoutError
+            If timeout is exceeded
+
+        Examples
+        --------
+        >>> import asyncio
+        >>> async def example():
+        ...     cmd = AsyncSubprocessCommand(['true'])
+        ...     return await cmd.wait()
+        >>> asyncio.run(example())
+        0
+        """
+        proc = await self._create_process(
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+        try:
+            if timeout is not None:
+                returncode = await asyncio.wait_for(
+                    proc.wait(),
+                    timeout=timeout,
+                )
+            else:
+                returncode = await proc.wait()
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
+
+        return returncode

--- a/src/libvcs/cmd/_async/__init__.py
+++ b/src/libvcs/cmd/_async/__init__.py
@@ -1,0 +1,21 @@
+"""Async command abstractions for VCS operations.
+
+This module provides async equivalents of the sync command classes
+in :mod:`libvcs.cmd`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+"""
+
+from __future__ import annotations
+
+from libvcs.cmd._async.git import AsyncGit
+from libvcs.cmd._async.hg import AsyncHg
+from libvcs.cmd._async.svn import AsyncSvn
+
+__all__ = [
+    "AsyncGit",
+    "AsyncHg",
+    "AsyncSvn",
+]

--- a/src/libvcs/cmd/_async/git.py
+++ b/src/libvcs/cmd/_async/git.py
@@ -1,0 +1,1334 @@
+"""Async git commands directly against a local git repo.
+
+Async equivalent of :mod:`libvcs.cmd.git`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import typing as t
+from collections.abc import Sequence
+
+from libvcs._internal.async_run import (
+    AsyncProgressCallbackProtocol,
+    async_run,
+)
+from libvcs._internal.types import StrOrBytesPath, StrPath
+
+_CMD = StrOrBytesPath | Sequence[StrOrBytesPath]
+
+
+class AsyncGit:
+    """Run commands directly on a git repository asynchronously.
+
+    Async equivalent of :class:`~libvcs.cmd.git.Git`.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to the git repository
+    progress_callback : AsyncProgressCallbackProtocol, optional
+        Async callback for progress reporting
+
+    Examples
+    --------
+    >>> async def example():
+    ...     git = AsyncGit(path=tmp_path)
+    ...     await git.run(['init'])
+    ...     status = await git.status()
+    ...     return 'On branch' in status or 'No commits yet' in status
+    >>> asyncio.run(example())
+    True
+    """
+
+    progress_callback: AsyncProgressCallbackProtocol | None = None
+
+    # Sub-commands (will be populated in __init__)
+    submodule: AsyncGitSubmoduleCmd
+    remotes: AsyncGitRemoteManager
+    stash: AsyncGitStashCmd
+
+    def __init__(
+        self,
+        *,
+        path: StrPath,
+        progress_callback: AsyncProgressCallbackProtocol | None = None,
+    ) -> None:
+        """Initialize AsyncGit command wrapper.
+
+        Parameters
+        ----------
+        path : str | Path
+            Path to the git repository
+        progress_callback : AsyncProgressCallbackProtocol, optional
+            Async callback for progress reporting
+        """
+        self.path: pathlib.Path
+        if isinstance(path, pathlib.Path):
+            self.path = path
+        else:
+            self.path = pathlib.Path(path)
+
+        self.progress_callback = progress_callback
+
+        # Initialize sub-command managers
+        self.submodule = AsyncGitSubmoduleCmd(path=self.path, cmd=self)
+        self.remotes = AsyncGitRemoteManager(path=self.path, cmd=self)
+        self.stash = AsyncGitStashCmd(path=self.path, cmd=self)
+
+    def __repr__(self) -> str:
+        """Representation of AsyncGit repo command object."""
+        return f"<AsyncGit path={self.path}>"
+
+    async def run(
+        self,
+        args: _CMD,
+        *,
+        # Normal flags
+        C: StrOrBytesPath | list[StrOrBytesPath] | None = None,
+        cwd: StrOrBytesPath | None = None,
+        git_dir: StrOrBytesPath | None = None,
+        work_tree: StrOrBytesPath | None = None,
+        namespace: StrOrBytesPath | None = None,
+        bare: bool | None = None,
+        no_replace_objects: bool | None = None,
+        literal_pathspecs: bool | None = None,
+        no_optional_locks: bool | None = None,
+        config: dict[str, t.Any] | None = None,
+        # Pass-through to async_run()
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Run a command for this git repository asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.run`.
+
+        Parameters
+        ----------
+        args : list[str] | str
+            Git subcommand and arguments
+        cwd : str | Path, optional
+            Working directory. Defaults to self.path.
+        config : dict[str, Any], optional
+            Git config options to pass via --config
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+
+        Examples
+        --------
+        >>> async def example():
+        ...     git = AsyncGit(path=tmp_path)
+        ...     await git.run(['init'])
+        ...     return 'On branch' in await git.run(['status'])
+        >>> asyncio.run(example())
+        True
+        """
+        cli_args: list[str]
+        if isinstance(args, Sequence) and not isinstance(args, (str, bytes)):
+            cli_args = ["git", *[str(a) for a in args]]
+        else:
+            cli_args = ["git", str(args)]
+
+        run_cwd = cwd if cwd is not None else self.path
+
+        # Build flags
+        if C is not None:
+            c_list = [C] if not isinstance(C, list) else C
+            for c in c_list:
+                cli_args.extend(["-C", str(c)])
+        if config is not None:
+            for k, v in config.items():
+                val = "true" if v is True else ("false" if v is False else str(v))
+                cli_args.extend(["--config", f"{k}={val}"])
+        if git_dir is not None:
+            cli_args.extend(["--git-dir", str(git_dir)])
+        if work_tree is not None:
+            cli_args.extend(["--work-tree", str(work_tree)])
+        if namespace is not None:
+            cli_args.extend(["--namespace", str(namespace)])
+        if bare is True:
+            cli_args.append("--bare")
+        if no_replace_objects is True:
+            cli_args.append("--no-replace-objects")
+        if literal_pathspecs is True:
+            cli_args.append("--literal-pathspecs")
+        if no_optional_locks is True:
+            cli_args.append("--no-optional-locks")
+
+        return await async_run(
+            args=cli_args,
+            cwd=run_cwd,
+            check_returncode=check_returncode,
+            callback=self.progress_callback if log_in_real_time else None,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def clone(
+        self,
+        *,
+        url: str,
+        depth: int | None = None,
+        branch: str | None = None,
+        origin: str | None = None,
+        progress: bool | None = None,
+        no_checkout: bool | None = None,
+        quiet: bool | None = None,
+        verbose: bool | None = None,
+        config: dict[str, t.Any] | None = None,
+        log_in_real_time: bool = False,
+        check_returncode: bool | None = None,
+        make_parents: bool | None = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Clone a working copy from a git repo asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.clone`.
+
+        Parameters
+        ----------
+        url : str
+            Repository URL to clone
+        depth : int, optional
+            Create a shallow clone with history truncated
+        branch : str, optional
+            Branch to checkout after clone
+        origin : str, optional
+            Name for the remote
+        progress : bool, optional
+            Force progress reporting
+        quiet : bool, optional
+            Suppress output
+        make_parents : bool, default True
+            Create parent directories if they don't exist
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+
+        Examples
+        --------
+        >>> async def example():
+        ...     repo_path = tmp_path / 'cloned_repo'
+        ...     git = AsyncGit(path=repo_path)
+        ...     url = f'file://{create_git_remote_repo()}'
+        ...     await git.clone(url=url)
+        ...     return (repo_path / '.git').exists()
+        >>> asyncio.run(example())
+        True
+        """
+        if make_parents and not self.path.exists():
+            self.path.mkdir(parents=True)
+
+        local_flags: list[str] = []
+        if depth is not None:
+            local_flags.extend(["--depth", str(depth)])
+        if branch is not None:
+            local_flags.extend(["--branch", branch])
+        if origin is not None:
+            local_flags.extend(["--origin", origin])
+        if quiet is True:
+            local_flags.append("--quiet")
+        if verbose is True:
+            local_flags.append("--verbose")
+        if progress is True:
+            local_flags.append("--progress")
+        if no_checkout is True:
+            local_flags.append("--no-checkout")
+
+        return await self.run(
+            ["clone", *local_flags, url, str(self.path)],
+            cwd=self.path.parent,
+            config=config,
+            log_in_real_time=log_in_real_time,
+            check_returncode=check_returncode if check_returncode is not None else True,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def fetch(
+        self,
+        *,
+        repository: str | None = None,
+        refspec: str | list[str] | None = None,
+        _all: bool | None = None,
+        append: bool | None = None,
+        depth: int | None = None,
+        force: bool | None = None,
+        prune: bool | None = None,
+        prune_tags: bool | None = None,
+        tags: bool | None = None,
+        no_tags: bool | None = None,
+        quiet: bool | None = None,
+        verbose: bool | None = None,
+        progress: bool | None = None,
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Fetch from remote repository asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.fetch`.
+
+        Parameters
+        ----------
+        repository : str, optional
+            Remote name to fetch from
+        refspec : str | list[str], optional
+            Refspec(s) to fetch
+        _all : bool, optional
+            Fetch all remotes
+        depth : int, optional
+            Deepen shallow clone
+        prune : bool, optional
+            Remove remote-tracking refs that no longer exist
+        tags : bool, optional
+            Fetch all tags
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+        if _all is True:
+            local_flags.append("--all")
+        if append is True:
+            local_flags.append("--append")
+        if depth is not None:
+            local_flags.extend(["--depth", str(depth)])
+        if force is True:
+            local_flags.append("--force")
+        if prune is True:
+            local_flags.append("--prune")
+        if prune_tags is True:
+            local_flags.append("--prune-tags")
+        if tags is True:
+            local_flags.append("--tags")
+        if no_tags is True:
+            local_flags.append("--no-tags")
+        if quiet is True:
+            local_flags.append("--quiet")
+        if verbose is True:
+            local_flags.append("--verbose")
+        if progress is True:
+            local_flags.append("--progress")
+
+        args: list[str] = ["fetch", *local_flags]
+        if repository is not None:
+            args.append(repository)
+        if refspec is not None:
+            if isinstance(refspec, list):
+                args.extend(refspec)
+            else:
+                args.append(refspec)
+
+        return await self.run(
+            args,
+            log_in_real_time=log_in_real_time,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def checkout(
+        self,
+        *,
+        branch: str | None = None,
+        pathspec: str | list[str] | None = None,
+        force: bool | None = None,
+        quiet: bool | None = None,
+        detach: bool | None = None,
+        track: bool | str | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Checkout a branch or paths asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.checkout`.
+
+        Parameters
+        ----------
+        branch : str, optional
+            Branch name to checkout
+        pathspec : str | list[str], optional
+            Path(s) to checkout
+        force : bool, optional
+            Force checkout (discard local changes)
+        quiet : bool, optional
+            Suppress output
+        detach : bool, optional
+            Detach HEAD at named commit
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+        if force is True:
+            local_flags.append("--force")
+        if quiet is True:
+            local_flags.append("--quiet")
+        if detach is True:
+            local_flags.append("--detach")
+        if track is True:
+            local_flags.append("--track")
+        elif isinstance(track, str):
+            local_flags.append(f"--track={track}")
+
+        args: list[str] = ["checkout", *local_flags]
+        if branch is not None:
+            args.append(branch)
+        if pathspec is not None:
+            args.append("--")
+            if isinstance(pathspec, list):
+                args.extend(pathspec)
+            else:
+                args.append(pathspec)
+
+        return await self.run(
+            args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def status(
+        self,
+        *,
+        short: bool | None = None,
+        branch: bool | None = None,
+        porcelain: bool | str | None = None,
+        untracked_files: str | None = None,
+        ignored: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Show working tree status asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.status`.
+
+        Parameters
+        ----------
+        short : bool, optional
+            Give output in short format
+        branch : bool, optional
+            Show branch info even in short format
+        porcelain : bool | str, optional
+            Machine-readable format
+        untracked_files : str, optional
+            Untracked files mode: "no", "normal", "all"
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Status output
+        """
+        local_flags: list[str] = []
+        if short is True:
+            local_flags.append("--short")
+        if branch is True:
+            local_flags.append("--branch")
+        if porcelain is True:
+            local_flags.append("--porcelain")
+        elif isinstance(porcelain, str):
+            local_flags.append(f"--porcelain={porcelain}")
+        if untracked_files is not None:
+            local_flags.append(f"--untracked-files={untracked_files}")
+        if ignored is True:
+            local_flags.append("--ignored")
+
+        return await self.run(
+            ["status", *local_flags],
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def rev_parse(
+        self,
+        *,
+        args: str | list[str] | None = None,
+        verify: bool | None = None,
+        short: bool | int | None = None,
+        abbrev_ref: bool | str | None = None,
+        show_toplevel: bool | None = None,
+        git_dir: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Parse git references asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.rev_parse`.
+
+        Parameters
+        ----------
+        args : str | list[str], optional
+            Revision arguments to parse
+        verify : bool, optional
+            Verify the parameter is a valid object name
+        short : bool | int, optional
+            Use short object name
+        abbrev_ref : bool | str, optional
+            Use abbreviated ref format
+        show_toplevel : bool, optional
+            Show path of top-level directory
+        git_dir : bool, optional
+            Show path of .git directory
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Parsed reference
+        """
+        local_flags: list[str] = []
+        if verify is True:
+            local_flags.append("--verify")
+        if short is True:
+            local_flags.append("--short")
+        elif isinstance(short, int):
+            local_flags.append(f"--short={short}")
+        if abbrev_ref is True:
+            local_flags.append("--abbrev-ref")
+        elif isinstance(abbrev_ref, str):
+            local_flags.append(f"--abbrev-ref={abbrev_ref}")
+        if show_toplevel is True:
+            local_flags.append("--show-toplevel")
+        if git_dir is True:
+            local_flags.append("--git-dir")
+
+        cmd_args: list[str] = ["rev-parse", *local_flags]
+        if args is not None:
+            if isinstance(args, list):
+                cmd_args.extend(args)
+            else:
+                cmd_args.append(args)
+
+        return await self.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def symbolic_ref(
+        self,
+        *,
+        name: str,
+        ref: str | None = None,
+        short: bool | None = None,
+        quiet: bool | None = None,
+        delete: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Read, modify, or delete symbolic refs asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.symbolic_ref`.
+
+        Parameters
+        ----------
+        name : str
+            Symbolic ref name
+        ref : str, optional
+            Ref to set symbolic ref to
+        short : bool, optional
+            Shorten ref name
+        quiet : bool, optional
+            Suppress error messages
+        delete : bool, optional
+            Delete symbolic ref
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Symbolic ref value
+        """
+        local_flags: list[str] = []
+        if short is True:
+            local_flags.append("--short")
+        if quiet is True:
+            local_flags.append("--quiet")
+        if delete is True:
+            local_flags.append("--delete")
+
+        cmd_args: list[str] = ["symbolic-ref", *local_flags, name]
+        if ref is not None:
+            cmd_args.append(ref)
+
+        return await self.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def rev_list(
+        self,
+        *,
+        commit: str | list[str] | None = None,
+        max_count: int | None = None,
+        abbrev_commit: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """List commit objects asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.rev_list`.
+
+        Parameters
+        ----------
+        commit : str | list[str], optional
+            Commit(s) to list
+        max_count : int, optional
+            Limit output to n commits
+        abbrev_commit : bool, optional
+            Show abbreviated commit IDs
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            List of commit objects
+        """
+        local_flags: list[str] = []
+        if max_count is not None:
+            local_flags.extend(["--max-count", str(max_count)])
+        if abbrev_commit is True:
+            local_flags.append("--abbrev-commit")
+
+        cmd_args: list[str] = ["rev-list", *local_flags]
+        if commit is not None:
+            if isinstance(commit, list):
+                cmd_args.extend(commit)
+            else:
+                cmd_args.append(commit)
+
+        return await self.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def show_ref(
+        self,
+        *,
+        pattern: str | list[str] | None = None,
+        heads: bool | None = None,
+        tags: bool | None = None,
+        hash_only: bool | None = None,
+        verify: bool | None = None,
+        quiet: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """List references asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.show_ref`.
+
+        Parameters
+        ----------
+        pattern : str | list[str], optional
+            Pattern(s) to filter refs
+        heads : bool, optional
+            Show only heads
+        tags : bool, optional
+            Show only tags
+        hash_only : bool, optional
+            Show only hash
+        verify : bool, optional
+            Verify ref exists
+        quiet : bool, optional
+            Suppress output (just exit status)
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Reference list
+        """
+        local_flags: list[str] = []
+        if heads is True:
+            local_flags.append("--heads")
+        if tags is True:
+            local_flags.append("--tags")
+        if hash_only is True:
+            local_flags.append("--hash")
+        if verify is True:
+            local_flags.append("--verify")
+        if quiet is True:
+            local_flags.append("--quiet")
+
+        cmd_args: list[str] = ["show-ref", *local_flags]
+        if pattern is not None:
+            if isinstance(pattern, list):
+                cmd_args.extend(pattern)
+            else:
+                cmd_args.append(pattern)
+
+        return await self.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def reset(
+        self,
+        *,
+        pathspec: str | list[str] | None = None,
+        soft: bool | None = None,
+        mixed: bool | None = None,
+        hard: bool | None = None,
+        merge: bool | None = None,
+        keep: bool | None = None,
+        quiet: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Reset current HEAD asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.reset`.
+
+        Parameters
+        ----------
+        pathspec : str | list[str], optional
+            Commit or paths to reset
+        soft : bool, optional
+            Reset HEAD only
+        mixed : bool, optional
+            Reset HEAD and index (default)
+        hard : bool, optional
+            Reset HEAD, index, and working tree
+        quiet : bool, optional
+            Suppress output
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+        if soft is True:
+            local_flags.append("--soft")
+        if mixed is True:
+            local_flags.append("--mixed")
+        if hard is True:
+            local_flags.append("--hard")
+        if merge is True:
+            local_flags.append("--merge")
+        if keep is True:
+            local_flags.append("--keep")
+        if quiet is True:
+            local_flags.append("--quiet")
+
+        cmd_args: list[str] = ["reset", *local_flags]
+        if pathspec is not None:
+            if isinstance(pathspec, list):
+                cmd_args.extend(pathspec)
+            else:
+                cmd_args.append(pathspec)
+
+        return await self.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def rebase(
+        self,
+        *,
+        upstream: str | None = None,
+        onto: str | None = None,
+        abort: bool | None = None,
+        _continue: bool | None = None,
+        skip: bool | None = None,
+        interactive: bool | None = None,
+        quiet: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Rebase commits asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.git.Git.rebase`.
+
+        Parameters
+        ----------
+        upstream : str, optional
+            Upstream branch to rebase onto
+        onto : str, optional
+            Starting point for rebase
+        abort : bool, optional
+            Abort current rebase
+        _continue : bool, optional
+            Continue current rebase
+        skip : bool, optional
+            Skip current patch
+        interactive : bool, optional
+            Interactive rebase (use with caution in async)
+        quiet : bool, optional
+            Suppress output
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+        if onto is not None:
+            local_flags.extend(["--onto", onto])
+        if abort is True:
+            local_flags.append("--abort")
+        if _continue is True:
+            local_flags.append("--continue")
+        if skip is True:
+            local_flags.append("--skip")
+        if interactive is True:
+            local_flags.append("--interactive")
+        if quiet is True:
+            local_flags.append("--quiet")
+
+        cmd_args: list[str] = ["rebase", *local_flags]
+        if upstream is not None:
+            cmd_args.append(upstream)
+
+        return await self.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def version(
+        self,
+        *,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Get git version asynchronously.
+
+        Returns
+        -------
+        str
+            Git version string
+        """
+        return await self.run(["version"], timeout=timeout, **kwargs)
+
+
+class AsyncGitSubmoduleCmd:
+    """Async git submodule commands.
+
+    Async equivalent of :class:`~libvcs.cmd.git.GitSubmoduleCmd`.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: StrPath,
+        cmd: AsyncGit,
+    ) -> None:
+        """Initialize submodule command wrapper."""
+        self.path: pathlib.Path
+        if isinstance(path, pathlib.Path):
+            self.path = path
+        else:
+            self.path = pathlib.Path(path)
+        self.cmd = cmd
+
+    async def init(
+        self,
+        *,
+        path: StrPath | list[StrPath] | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Initialize submodules asynchronously.
+
+        Parameters
+        ----------
+        path : str | Path | list, optional
+            Submodule path(s) to initialize
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        cmd_args: list[str] = ["submodule", "init"]
+        if path is not None:
+            if isinstance(path, list):
+                cmd_args.extend([str(p) for p in path])
+            else:
+                cmd_args.append(str(path))
+
+        return await self.cmd.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def update(
+        self,
+        *,
+        path: StrPath | list[StrPath] | None = None,
+        init: bool | None = None,
+        recursive: bool | None = None,
+        force: bool | None = None,
+        remote: bool | None = None,
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Update submodules asynchronously.
+
+        Parameters
+        ----------
+        path : str | Path | list, optional
+            Submodule path(s) to update
+        init : bool, optional
+            Initialize uninitialized submodules
+        recursive : bool, optional
+            Update nested submodules
+        force : bool, optional
+            Force checkout
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+        if init is True:
+            local_flags.append("--init")
+        if recursive is True:
+            local_flags.append("--recursive")
+        if force is True:
+            local_flags.append("--force")
+        if remote is True:
+            local_flags.append("--remote")
+
+        cmd_args: list[str] = ["submodule", "update", *local_flags]
+        if path is not None:
+            cmd_args.append("--")
+            if isinstance(path, list):
+                cmd_args.extend([str(p) for p in path])
+            else:
+                cmd_args.append(str(path))
+
+        return await self.cmd.run(
+            cmd_args,
+            log_in_real_time=log_in_real_time,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+
+class AsyncGitRemoteManager:
+    """Async git remote management commands.
+
+    Async equivalent of :class:`~libvcs.cmd.git.GitRemoteManager`.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: StrPath,
+        cmd: AsyncGit,
+    ) -> None:
+        """Initialize remote manager."""
+        self.path: pathlib.Path
+        if isinstance(path, pathlib.Path):
+            self.path = path
+        else:
+            self.path = pathlib.Path(path)
+        self.cmd = cmd
+
+    async def ls(
+        self,
+        *,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> list[str]:
+        """List remote names asynchronously.
+
+        Returns
+        -------
+        list[str]
+            List of remote names
+        """
+        output = await self.cmd.run(["remote"], timeout=timeout, **kwargs)
+        if not output.strip():
+            return []
+        return output.strip().split("\n")
+
+    async def show(
+        self,
+        *,
+        name: str | None = None,
+        verbose: bool | None = None,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Show remotes asynchronously.
+
+        Parameters
+        ----------
+        name : str, optional
+            Remote name to show details for
+        verbose : bool, optional
+            Show URLs
+
+        Returns
+        -------
+        str
+            Remote information
+        """
+        local_flags: list[str] = []
+        if verbose is True:
+            local_flags.append("--verbose")
+
+        cmd_args: list[str] = ["remote", *local_flags]
+        if name is not None:
+            cmd_args.extend(["show", name])
+
+        return await self.cmd.run(cmd_args, timeout=timeout, **kwargs)
+
+    async def add(
+        self,
+        *,
+        name: str,
+        url: str,
+        fetch: bool | None = None,
+        tags: bool | None = None,
+        no_tags: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Add a remote asynchronously.
+
+        Parameters
+        ----------
+        name : str
+            Remote name
+        url : str
+            Remote URL
+        fetch : bool, optional
+            Fetch after adding
+        tags : bool, optional
+            Import tags
+        no_tags : bool, optional
+            Don't import tags
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+        if fetch is True:
+            local_flags.append("--fetch")
+        if tags is True:
+            local_flags.append("--tags")
+        if no_tags is True:
+            local_flags.append("--no-tags")
+
+        return await self.cmd.run(
+            ["remote", "add", *local_flags, name, url],
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def remove(
+        self,
+        *,
+        name: str,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Remove a remote asynchronously.
+
+        Parameters
+        ----------
+        name : str
+            Remote name to remove
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        return await self.cmd.run(
+            ["remote", "remove", name],
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def get_url(
+        self,
+        *,
+        name: str,
+        push: bool | None = None,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Get URL for a remote asynchronously.
+
+        Parameters
+        ----------
+        name : str
+            Remote name
+        push : bool, optional
+            Get push URL
+
+        Returns
+        -------
+        str
+            Remote URL
+        """
+        local_flags: list[str] = []
+        if push is True:
+            local_flags.append("--push")
+
+        return await self.cmd.run(
+            ["remote", "get-url", *local_flags, name],
+            timeout=timeout,
+            **kwargs,
+        )
+
+
+class AsyncGitStashCmd:
+    """Async git stash commands.
+
+    Async equivalent of :class:`~libvcs.cmd.git.GitStashCmd`.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: StrPath,
+        cmd: AsyncGit,
+    ) -> None:
+        """Initialize stash command wrapper."""
+        self.path: pathlib.Path
+        if isinstance(path, pathlib.Path):
+            self.path = path
+        else:
+            self.path = pathlib.Path(path)
+        self.cmd = cmd
+
+    async def ls(
+        self,
+        *,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """List stashes asynchronously.
+
+        Returns
+        -------
+        str
+            Stash list
+        """
+        return await self.cmd.run(["stash", "list"], timeout=timeout, **kwargs)
+
+    async def save(
+        self,
+        *,
+        message: str | None = None,
+        keep_index: bool | None = None,
+        include_untracked: bool | None = None,
+        all_files: bool | None = None,
+        quiet: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Save changes to stash asynchronously.
+
+        Parameters
+        ----------
+        message : str, optional
+            Stash message
+        keep_index : bool, optional
+            Keep staged changes in index
+        include_untracked : bool, optional
+            Include untracked files
+        all_files : bool, optional
+            Include ignored files too
+        quiet : bool, optional
+            Suppress output
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+        if keep_index is True:
+            local_flags.append("--keep-index")
+        if include_untracked is True:
+            local_flags.append("--include-untracked")
+        if all_files is True:
+            local_flags.append("--all")
+        if quiet is True:
+            local_flags.append("--quiet")
+
+        cmd_args: list[str] = ["stash", "save", *local_flags]
+        if message is not None:
+            cmd_args.append(message)
+
+        return await self.cmd.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def pop(
+        self,
+        *,
+        stash: str | None = None,
+        index: bool | None = None,
+        quiet: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Pop stash asynchronously.
+
+        Parameters
+        ----------
+        stash : str, optional
+            Stash to pop (defaults to latest)
+        index : bool, optional
+            Also restore index
+        quiet : bool, optional
+            Suppress output
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+        if index is True:
+            local_flags.append("--index")
+        if quiet is True:
+            local_flags.append("--quiet")
+
+        cmd_args: list[str] = ["stash", "pop", *local_flags]
+        if stash is not None:
+            cmd_args.append(stash)
+
+        return await self.cmd.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def drop(
+        self,
+        *,
+        stash: str | None = None,
+        quiet: bool | None = None,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Drop stash asynchronously.
+
+        Parameters
+        ----------
+        stash : str, optional
+            Stash to drop (defaults to latest)
+        quiet : bool, optional
+            Suppress output
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+        if quiet is True:
+            local_flags.append("--quiet")
+
+        cmd_args: list[str] = ["stash", "drop", *local_flags]
+        if stash is not None:
+            cmd_args.append(stash)
+
+        return await self.cmd.run(
+            cmd_args,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def clear(
+        self,
+        *,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Clear all stashes asynchronously.
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        return await self.cmd.run(["stash", "clear"], timeout=timeout, **kwargs)

--- a/src/libvcs/cmd/_async/hg.py
+++ b/src/libvcs/cmd/_async/hg.py
@@ -1,0 +1,373 @@
+"""Async hg (Mercurial) commands directly against a local mercurial repo.
+
+Async equivalent of :mod:`libvcs.cmd.hg`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+"""
+
+from __future__ import annotations
+
+import enum
+import pathlib
+import typing as t
+from collections.abc import Sequence
+
+from libvcs._internal.async_run import (
+    AsyncProgressCallbackProtocol,
+    async_run,
+)
+from libvcs._internal.types import StrOrBytesPath, StrPath
+
+_CMD = StrOrBytesPath | Sequence[StrOrBytesPath]
+
+
+class HgColorType(enum.Enum):
+    """CLI Color enum for Mercurial."""
+
+    boolean = "boolean"
+    always = "always"
+    auto = "auto"
+    never = "never"
+    debug = "debug"
+
+
+class HgPagerType(enum.Enum):
+    """CLI Pagination enum for Mercurial."""
+
+    boolean = "boolean"
+    always = "always"
+    auto = "auto"
+    never = "never"
+
+
+class AsyncHg:
+    """Run commands directly on a Mercurial repository asynchronously.
+
+    Async equivalent of :class:`~libvcs.cmd.hg.Hg`.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to the hg repository
+    progress_callback : AsyncProgressCallbackProtocol, optional
+        Async callback for progress reporting
+
+    Examples
+    --------
+    >>> async def example():
+    ...     repo_path = tmp_path / 'hg_repo'
+    ...     hg = AsyncHg(path=repo_path)
+    ...     url = f'file://{create_hg_remote_repo()}'
+    ...     await hg.clone(url=url)
+    ...     return (repo_path / '.hg').exists()
+    >>> asyncio.run(example())
+    True
+    """
+
+    progress_callback: AsyncProgressCallbackProtocol | None = None
+
+    def __init__(
+        self,
+        *,
+        path: StrPath,
+        progress_callback: AsyncProgressCallbackProtocol | None = None,
+    ) -> None:
+        """Initialize AsyncHg command wrapper.
+
+        Parameters
+        ----------
+        path : str | Path
+            Path to the hg repository
+        progress_callback : AsyncProgressCallbackProtocol, optional
+            Async callback for progress reporting
+        """
+        self.path: pathlib.Path
+        if isinstance(path, pathlib.Path):
+            self.path = path
+        else:
+            self.path = pathlib.Path(path)
+
+        self.progress_callback = progress_callback
+
+    def __repr__(self) -> str:
+        """Representation of AsyncHg repo command object."""
+        return f"<AsyncHg path={self.path}>"
+
+    async def run(
+        self,
+        args: _CMD,
+        *,
+        config: str | None = None,
+        repository: str | None = None,
+        quiet: bool | None = None,
+        _help: bool | None = None,
+        encoding: str | None = None,
+        encoding_mode: str | None = None,
+        verbose: bool | None = None,
+        traceback: bool | None = None,
+        debug: bool | None = None,
+        debugger: bool | None = None,
+        profile: bool | None = None,
+        version: bool | None = None,
+        hidden: bool | None = None,
+        time: bool | None = None,
+        pager: HgPagerType | None = None,
+        color: HgColorType | None = None,
+        # Pass-through to async_run()
+        cwd: StrOrBytesPath | None = None,
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Run a command for this Mercurial repository asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.hg.Hg.run`.
+
+        Parameters
+        ----------
+        args : list[str] | str
+            Hg subcommand and arguments
+        quiet : bool, optional
+            -q / --quiet
+        repository : str, optional
+            --repository REPO
+        cwd : str | Path, optional
+            Working directory. Defaults to self.path.
+        verbose : bool, optional
+            -v / --verbose
+        color : HgColorType, optional
+            --color
+        debug : bool, optional
+            --debug
+        config : str, optional
+            --config CONFIG, section.name=value
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        cli_args: list[str]
+        if isinstance(args, Sequence) and not isinstance(args, (str, bytes)):
+            cli_args = ["hg", *[str(a) for a in args]]
+        else:
+            cli_args = ["hg", str(args)]
+
+        run_cwd = cwd if cwd is not None else self.path
+
+        # Build flags
+        if repository is not None:
+            cli_args.extend(["--repository", repository])
+        if config is not None:
+            cli_args.extend(["--config", config])
+        if pager is not None:
+            cli_args.extend(["--pager", pager.value])
+        if color is not None:
+            cli_args.extend(["--color", color.value])
+        if verbose is True:
+            cli_args.append("--verbose")
+        if quiet is True:
+            cli_args.append("--quiet")
+        if debug is True:
+            cli_args.append("--debug")
+        if debugger is True:
+            cli_args.append("--debugger")
+        if traceback is True:
+            cli_args.append("--traceback")
+        if time is True:
+            cli_args.append("--time")
+        if profile is True:
+            cli_args.append("--profile")
+        if version is True:
+            cli_args.append("--version")
+        if _help is True:
+            cli_args.append("--help")
+
+        return await async_run(
+            cli_args,
+            cwd=run_cwd,
+            callback=self.progress_callback if log_in_real_time else None,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def clone(
+        self,
+        *,
+        url: str,
+        no_update: bool | None = None,
+        update_rev: str | None = None,
+        rev: str | None = None,
+        branch: str | None = None,
+        ssh: str | None = None,
+        remote_cmd: str | None = None,
+        pull: bool | None = None,
+        stream: bool | None = None,
+        insecure: bool | None = None,
+        quiet: bool | None = None,
+        # Special behavior
+        make_parents: bool | None = True,
+        # Pass-through
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+    ) -> str:
+        """Clone a working copy from a mercurial repo asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.hg.Hg.clone`.
+
+        Parameters
+        ----------
+        url : str
+            URL of the repository to clone
+        no_update : bool, optional
+            Don't update the working directory
+        rev : str, optional
+            Revision to clone
+        branch : str, optional
+            Branch to clone
+        ssh : str, optional
+            SSH command to use
+        make_parents : bool, default True
+            Creates checkout directory if it doesn't exist
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        required_flags: list[str] = [url, str(self.path)]
+        local_flags: list[str] = []
+
+        if ssh is not None:
+            local_flags.extend(["--ssh", ssh])
+        if remote_cmd is not None:
+            local_flags.extend(["--remotecmd", remote_cmd])
+        if rev is not None:
+            local_flags.extend(["--rev", rev])
+        if branch is not None:
+            local_flags.extend(["--branch", branch])
+        if no_update is True:
+            local_flags.append("--noupdate")
+        if pull is True:
+            local_flags.append("--pull")
+        if stream is True:
+            local_flags.append("--stream")
+        if insecure is True:
+            local_flags.append("--insecure")
+        if quiet is True:
+            local_flags.append("--quiet")
+
+        # libvcs special behavior
+        if make_parents and not self.path.exists():
+            self.path.mkdir(parents=True)
+
+        return await self.run(
+            ["clone", *local_flags, "--", *required_flags],
+            log_in_real_time=log_in_real_time,
+            check_returncode=check_returncode,
+            timeout=timeout,
+        )
+
+    async def update(
+        self,
+        quiet: bool | None = None,
+        verbose: bool | None = None,
+        # Pass-through
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+    ) -> str:
+        """Update working directory asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.hg.Hg.update`.
+
+        Parameters
+        ----------
+        quiet : bool, optional
+            Suppress output
+        verbose : bool, optional
+            Enable verbose output
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+
+        if quiet:
+            local_flags.append("--quiet")
+        if verbose:
+            local_flags.append("--verbose")
+
+        return await self.run(
+            ["update", *local_flags],
+            log_in_real_time=log_in_real_time,
+            check_returncode=check_returncode,
+            timeout=timeout,
+        )
+
+    async def pull(
+        self,
+        quiet: bool | None = None,
+        verbose: bool | None = None,
+        update: bool | None = None,
+        # Pass-through
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+    ) -> str:
+        """Pull changes from remote asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.hg.Hg.pull`.
+
+        Parameters
+        ----------
+        quiet : bool, optional
+            Suppress output
+        verbose : bool, optional
+            Enable verbose output
+        update : bool, optional
+            Update to new branch head after pull
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+
+        if quiet:
+            local_flags.append("--quiet")
+        if verbose:
+            local_flags.append("--verbose")
+        if update:
+            local_flags.append("--update")
+
+        return await self.run(
+            ["pull", *local_flags],
+            log_in_real_time=log_in_real_time,
+            check_returncode=check_returncode,
+            timeout=timeout,
+        )

--- a/src/libvcs/cmd/_async/svn.py
+++ b/src/libvcs/cmd/_async/svn.py
@@ -1,0 +1,384 @@
+"""Async svn (subversion) commands directly against SVN working copy.
+
+Async equivalent of :mod:`libvcs.cmd.svn`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import typing as t
+from collections.abc import Sequence
+
+from libvcs._internal.async_run import (
+    AsyncProgressCallbackProtocol,
+    async_run,
+)
+from libvcs._internal.types import StrOrBytesPath, StrPath
+
+_CMD = StrOrBytesPath | Sequence[StrOrBytesPath]
+
+DepthLiteral = t.Literal["infinity", "empty", "files", "immediates"] | None
+RevisionLiteral = t.Literal["HEAD", "BASE", "COMMITTED", "PREV"] | None
+
+
+class AsyncSvn:
+    """Run commands directly on a Subversion working copy asynchronously.
+
+    Async equivalent of :class:`~libvcs.cmd.svn.Svn`.
+
+    Parameters
+    ----------
+    path : str | Path
+        Path to the SVN working copy
+    progress_callback : AsyncProgressCallbackProtocol, optional
+        Async callback for progress reporting
+
+    Examples
+    --------
+    >>> async def example():
+    ...     repo_path = tmp_path / 'svn_wc'
+    ...     svn = AsyncSvn(path=repo_path)
+    ...     url = f'file://{create_svn_remote_repo()}'
+    ...     await svn.checkout(url=url)
+    ...     return (repo_path / '.svn').exists()
+    >>> asyncio.run(example())
+    True
+    """
+
+    progress_callback: AsyncProgressCallbackProtocol | None = None
+
+    def __init__(
+        self,
+        *,
+        path: StrPath,
+        progress_callback: AsyncProgressCallbackProtocol | None = None,
+    ) -> None:
+        """Initialize AsyncSvn command wrapper.
+
+        Parameters
+        ----------
+        path : str | Path
+            Path to the SVN working copy
+        progress_callback : AsyncProgressCallbackProtocol, optional
+            Async callback for progress reporting
+        """
+        self.path: pathlib.Path
+        if isinstance(path, pathlib.Path):
+            self.path = path
+        else:
+            self.path = pathlib.Path(path)
+
+        self.progress_callback = progress_callback
+
+    def __repr__(self) -> str:
+        """Representation of AsyncSvn command object."""
+        return f"<AsyncSvn path={self.path}>"
+
+    async def run(
+        self,
+        args: _CMD,
+        *,
+        quiet: bool | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        no_auth_cache: bool | None = None,
+        non_interactive: bool | None = True,
+        trust_server_cert: bool | None = None,
+        config_dir: pathlib.Path | None = None,
+        config_option: pathlib.Path | None = None,
+        # Pass-through to async_run()
+        cwd: StrOrBytesPath | None = None,
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Run a command for this SVN working copy asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.svn.Svn.run`.
+
+        Parameters
+        ----------
+        args : list[str] | str
+            SVN subcommand and arguments
+        quiet : bool, optional
+            -q / --quiet
+        username : str, optional
+            --username
+        password : str, optional
+            --password
+        no_auth_cache : bool, optional
+            --no-auth-cache
+        non_interactive : bool, default True
+            --non-interactive
+        trust_server_cert : bool, optional
+            --trust-server-cert
+        config_dir : Path, optional
+            --config-dir
+        cwd : str | Path, optional
+            Working directory. Defaults to self.path.
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        cli_args: list[str]
+        if isinstance(args, Sequence) and not isinstance(args, (str, bytes)):
+            cli_args = ["svn", *[str(a) for a in args]]
+        else:
+            cli_args = ["svn", str(args)]
+
+        run_cwd = cwd if cwd is not None else self.path
+
+        # Build flags
+        if no_auth_cache is True:
+            cli_args.append("--no-auth-cache")
+        if non_interactive is True:
+            cli_args.append("--non-interactive")
+        if username is not None:
+            cli_args.extend(["--username", username])
+        if password is not None:
+            cli_args.extend(["--password", password])
+        if trust_server_cert is True:
+            cli_args.append("--trust-server-cert")
+        if config_dir is not None:
+            cli_args.extend(["--config-dir", str(config_dir)])
+        if config_option is not None:
+            cli_args.extend(["--config-option", str(config_option)])
+
+        return await async_run(
+            cli_args,
+            cwd=run_cwd,
+            callback=self.progress_callback if log_in_real_time else None,
+            check_returncode=check_returncode,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def checkout(
+        self,
+        *,
+        url: str,
+        revision: RevisionLiteral | str = None,
+        force: bool | None = None,
+        ignore_externals: bool | None = None,
+        depth: DepthLiteral = None,
+        quiet: bool | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        no_auth_cache: bool | None = None,
+        non_interactive: bool | None = True,
+        trust_server_cert: bool | None = None,
+        # Special behavior
+        make_parents: bool | None = True,
+        # Pass-through
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+    ) -> str:
+        """Check out a working copy from an SVN repo asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.svn.Svn.checkout`.
+
+        Parameters
+        ----------
+        url : str
+            Repository URL to checkout
+        revision : str, optional
+            Number, '{ DATE }', 'HEAD', 'BASE', 'COMMITTED', 'PREV'
+        force : bool, optional
+            Force operation to run
+        ignore_externals : bool, optional
+            Ignore externals definitions
+        depth : str, optional
+            Sparse checkout depth
+        quiet : bool, optional
+            Suppress output
+        username : str, optional
+            SVN username
+        password : str, optional
+            SVN password
+        make_parents : bool, default True
+            Create checkout directory if it doesn't exist
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        # URL and PATH come first, matching sync Svn.checkout pattern
+        local_flags: list[str] = [url, str(self.path)]
+
+        if revision is not None:
+            local_flags.extend(["--revision", str(revision)])
+        if depth is not None:
+            local_flags.extend(["--depth", depth])
+        if force is True:
+            local_flags.append("--force")
+        if ignore_externals is True:
+            local_flags.append("--ignore-externals")
+        if quiet is True:
+            local_flags.append("--quiet")
+
+        # libvcs special behavior
+        if make_parents and not self.path.exists():
+            self.path.mkdir(parents=True)
+
+        return await self.run(
+            ["checkout", *local_flags],
+            username=username,
+            password=password,
+            no_auth_cache=no_auth_cache,
+            non_interactive=non_interactive,
+            trust_server_cert=trust_server_cert,
+            log_in_real_time=log_in_real_time,
+            check_returncode=check_returncode,
+            timeout=timeout,
+        )
+
+    async def update(
+        self,
+        accept: str | None = None,
+        force: bool | None = None,
+        ignore_externals: bool | None = None,
+        parents: bool | None = None,
+        quiet: bool | None = None,
+        revision: str | None = None,
+        set_depth: str | None = None,
+        # Pass-through
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+    ) -> str:
+        """Fetch latest changes to working copy asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.svn.Svn.update`.
+
+        Parameters
+        ----------
+        accept : str, optional
+            Conflict resolution action
+        force : bool, optional
+            Force operation
+        ignore_externals : bool, optional
+            Ignore externals definitions
+        parents : bool, optional
+            Make intermediate directories
+        quiet : bool, optional
+            Suppress output
+        revision : str, optional
+            Update to specific revision
+        set_depth : str, optional
+            Set new working copy depth
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output
+        """
+        local_flags: list[str] = []
+
+        if revision is not None:
+            local_flags.extend(["--revision", revision])
+        if set_depth is not None:
+            local_flags.extend(["--set-depth", set_depth])
+        if accept is not None:
+            local_flags.extend(["--accept", accept])
+        if force is True:
+            local_flags.append("--force")
+        if ignore_externals is True:
+            local_flags.append("--ignore-externals")
+        if parents is True:
+            local_flags.append("--parents")
+        if quiet is True:
+            local_flags.append("--quiet")
+
+        return await self.run(
+            ["update", *local_flags],
+            log_in_real_time=log_in_real_time,
+            check_returncode=check_returncode,
+            timeout=timeout,
+        )
+
+    async def info(
+        self,
+        target: StrPath | None = None,
+        revision: str | None = None,
+        depth: DepthLiteral = None,
+        incremental: bool | None = None,
+        recursive: bool | None = None,
+        xml: bool | None = None,
+        # Pass-through
+        log_in_real_time: bool = False,
+        check_returncode: bool = True,
+        timeout: float | None = None,
+    ) -> str:
+        """Return info about this SVN repository asynchronously.
+
+        Async equivalent of :meth:`~libvcs.cmd.svn.Svn.info`.
+
+        Parameters
+        ----------
+        target : str | Path, optional
+            Target path or URL
+        revision : str, optional
+            Revision to get info for
+        depth : str, optional
+            Limit operation depth
+        incremental : bool, optional
+            Give output suitable for concatenation
+        recursive : bool, optional
+            Descend recursively
+        xml : bool, optional
+            Output in XML format
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Command output (optionally XML)
+        """
+        local_flags: list[str] = []
+
+        if isinstance(target, pathlib.Path):
+            local_flags.append(str(target.absolute()))
+        elif isinstance(target, str):
+            local_flags.append(target)
+
+        if revision is not None:
+            local_flags.extend(["--revision", revision])
+        if depth is not None:
+            local_flags.extend(["--depth", depth])
+        if incremental is True:
+            local_flags.append("--incremental")
+        if recursive is True:
+            local_flags.append("--recursive")
+        if xml is True:
+            local_flags.append("--xml")
+
+        return await self.run(
+            ["info", *local_flags],
+            log_in_real_time=log_in_real_time,
+            check_returncode=check_returncode,
+            timeout=timeout,
+        )

--- a/src/libvcs/pytest_plugin.py
+++ b/src/libvcs/pytest_plugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import functools
 import getpass
 import pathlib
@@ -17,6 +18,18 @@ from libvcs._internal.run import _ENV, run
 from libvcs.sync.git import GitRemote, GitSync
 from libvcs.sync.hg import HgSync
 from libvcs.sync.svn import SvnSync
+
+# Async support - conditional import
+try:
+    import pytest_asyncio
+
+    from libvcs.sync._async.git import AsyncGitSync
+    from libvcs.sync._async.hg import AsyncHgSync
+    from libvcs.sync._async.svn import AsyncSvnSync
+
+    HAS_PYTEST_ASYNCIO = True
+except ImportError:
+    HAS_PYTEST_ASYNCIO = False
 
 
 class MaxUniqueRepoAttemptsExceeded(exc.LibVCSException):
@@ -784,6 +797,133 @@ def svn_repo(
     return svn_repo
 
 
+# =============================================================================
+# Async Fixtures
+# =============================================================================
+
+if HAS_PYTEST_ASYNCIO:
+
+    @pytest_asyncio.fixture
+    @skip_if_git_missing
+    async def async_git_repo(
+        remote_repos_path: pathlib.Path,
+        projects_path: pathlib.Path,
+        git_remote_repo: pathlib.Path,
+        set_gitconfig: pathlib.Path,
+    ) -> t.AsyncGenerator[AsyncGitSync, None]:
+        """Pre-made async git clone of remote repo checked out to user's projects dir.
+
+        Async equivalent of :func:`git_repo` fixture.
+
+        Examples
+        --------
+        >>> @pytest.mark.asyncio
+        ... async def test_git_operations(async_git_repo):
+        ...     status = await async_git_repo.cmd.status()
+        """
+        remote_repo_name = unique_repo_name(remote_repos_path=projects_path)
+        new_checkout_path = projects_path / remote_repo_name
+        master_copy = remote_repos_path / "git_repo"
+
+        if master_copy.exists():
+            shutil.copytree(master_copy, new_checkout_path)
+            yield AsyncGitSync(
+                url=f"file://{git_remote_repo}",
+                path=new_checkout_path,
+            )
+            return
+
+        sync_repo = GitSync(
+            url=f"file://{git_remote_repo}",
+            path=master_copy,
+            remotes={
+                "origin": GitRemote(
+                    name="origin",
+                    push_url=f"file://{git_remote_repo}",
+                    fetch_url=f"file://{git_remote_repo}",
+                ),
+            },
+        )
+        sync_repo.obtain()
+        shutil.copytree(master_copy, new_checkout_path)
+        yield AsyncGitSync(url=f"file://{git_remote_repo}", path=new_checkout_path)
+
+    @pytest_asyncio.fixture
+    @skip_if_hg_missing
+    async def async_hg_repo(
+        remote_repos_path: pathlib.Path,
+        projects_path: pathlib.Path,
+        hg_remote_repo: pathlib.Path,
+        set_hgconfig: pathlib.Path,
+    ) -> t.AsyncGenerator[AsyncHgSync, None]:
+        """Pre-made async hg clone of remote repo checked out to user's projects dir.
+
+        Async equivalent of :func:`hg_repo` fixture.
+
+        Examples
+        --------
+        >>> @pytest.mark.asyncio
+        ... async def test_hg_operations(async_hg_repo):
+        ...     status = await async_hg_repo.cmd.status()
+        """
+        remote_repo_name = unique_repo_name(remote_repos_path=projects_path)
+        new_checkout_path = projects_path / remote_repo_name
+        master_copy = remote_repos_path / "hg_repo"
+
+        if master_copy.exists():
+            shutil.copytree(master_copy, new_checkout_path)
+            yield AsyncHgSync(
+                url=f"file://{hg_remote_repo}",
+                path=new_checkout_path,
+            )
+            return
+
+        sync_repo = HgSync(
+            url=f"file://{hg_remote_repo}",
+            path=master_copy,
+        )
+        sync_repo.obtain()
+        shutil.copytree(master_copy, new_checkout_path)
+        yield AsyncHgSync(url=f"file://{hg_remote_repo}", path=new_checkout_path)
+
+    @pytest_asyncio.fixture
+    @skip_if_svn_missing
+    async def async_svn_repo(
+        remote_repos_path: pathlib.Path,
+        projects_path: pathlib.Path,
+        svn_remote_repo: pathlib.Path,
+    ) -> t.AsyncGenerator[AsyncSvnSync, None]:
+        """Pre-made async svn checkout of remote repo.
+
+        Async equivalent of :func:`svn_repo` fixture.
+
+        Examples
+        --------
+        >>> @pytest.mark.asyncio
+        ... async def test_svn_operations(async_svn_repo):
+        ...     status = await async_svn_repo.cmd.status()
+        """
+        remote_repo_name = unique_repo_name(remote_repos_path=projects_path)
+        new_checkout_path = projects_path / remote_repo_name
+        master_copy = remote_repos_path / "svn_repo"
+
+        if master_copy.exists():
+            shutil.copytree(master_copy, new_checkout_path)
+            yield AsyncSvnSync(
+                url=f"file://{svn_remote_repo}",
+                path=new_checkout_path,
+            )
+            return
+
+        sync_repo = SvnSync(
+            url=f"file://{svn_remote_repo}",
+            path=str(master_copy),
+        )
+        sync_repo.obtain()
+        shutil.copytree(master_copy, new_checkout_path)
+        yield AsyncSvnSync(url=f"file://{svn_remote_repo}", path=new_checkout_path)
+
+
 @pytest.fixture
 def add_doctest_fixtures(
     request: pytest.FixtureRequest,
@@ -802,6 +942,8 @@ def add_doctest_fixtures(
 
     if not isinstance(request._pyfuncitem, DoctestItem):  # Only run on doctest items
         return
+    # Add asyncio for async doctests
+    doctest_namespace["asyncio"] = asyncio
     doctest_namespace["tmp_path"] = tmp_path
     if shutil.which("git"):
         doctest_namespace["create_git_remote_repo"] = functools.partial(

--- a/src/libvcs/sync/_async/__init__.py
+++ b/src/libvcs/sync/_async/__init__.py
@@ -1,0 +1,21 @@
+"""Async repository synchronization classes.
+
+This module provides async equivalents of the sync classes
+in :mod:`libvcs.sync`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+"""
+
+from __future__ import annotations
+
+from libvcs.sync._async.git import AsyncGitSync
+from libvcs.sync._async.hg import AsyncHgSync
+from libvcs.sync._async.svn import AsyncSvnSync
+
+__all__ = [
+    "AsyncGitSync",
+    "AsyncHgSync",
+    "AsyncSvnSync",
+]

--- a/src/libvcs/sync/_async/base.py
+++ b/src/libvcs/sync/_async/base.py
@@ -1,0 +1,190 @@
+"""Foundational tools for async VCS managers.
+
+Async equivalent of :mod:`libvcs.sync.base`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import typing as t
+from urllib import parse as urlparse
+
+from libvcs._internal.async_run import (
+    AsyncProgressCallbackProtocol,
+    async_run,
+)
+from libvcs._internal.run import CmdLoggingAdapter
+from libvcs._internal.types import StrPath
+from libvcs.sync.base import convert_pip_url
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncBaseSync:
+    """Base class for async repository synchronization.
+
+    Async equivalent of :class:`~libvcs.sync.base.BaseSync`.
+    """
+
+    log_in_real_time: bool | None = None
+    """Log command output to buffer"""
+
+    bin_name: str = ""
+    """VCS app name, e.g. 'git'"""
+
+    schemes: tuple[str, ...] = ()
+    """List of supported schemes to register in urlparse.uses_netloc"""
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        path: StrPath,
+        progress_callback: AsyncProgressCallbackProtocol | None = None,
+        **kwargs: t.Any,
+    ) -> None:
+        """Initialize async VCS synchronization object.
+
+        Parameters
+        ----------
+        url : str
+            URL of the repository
+        path : str | Path
+            Local path for the repository
+        progress_callback : AsyncProgressCallbackProtocol, optional
+            Async callback for progress updates
+
+        Examples
+        --------
+        >>> import asyncio
+        >>> class MyRepo(AsyncBaseSync):
+        ...     bin_name = 'git'
+        ...     async def obtain(self):
+        ...         await self.run(['clone', self.url, str(self.path)])
+        """
+        self.url = url
+
+        #: Async callback for run updates
+        self.progress_callback = progress_callback
+
+        #: Directory to check out
+        self.path: pathlib.Path
+        if isinstance(path, pathlib.Path):
+            self.path = path
+        else:
+            self.path = pathlib.Path(path)
+
+        if "rev" in kwargs:
+            self.rev = kwargs["rev"]
+
+        # Register schemes with urlparse
+        if hasattr(self, "schemes"):
+            urlparse.uses_netloc.extend(self.schemes)
+            if getattr(urlparse, "uses_fragment", None):
+                urlparse.uses_fragment.extend(self.schemes)
+
+        #: Logging attribute
+        self.log: CmdLoggingAdapter = CmdLoggingAdapter(
+            bin_name=self.bin_name,
+            keyword=self.repo_name,
+            logger=logger,
+            extra={},
+        )
+
+    @property
+    def repo_name(self) -> str:
+        """Return the short name of a repo checkout."""
+        return self.path.stem
+
+    @classmethod
+    def from_pip_url(cls, pip_url: str, **kwargs: t.Any) -> AsyncBaseSync:
+        """Create async synchronization object from pip-style URL."""
+        url, rev = convert_pip_url(pip_url)
+        return cls(url=url, rev=rev, **kwargs)
+
+    async def run(
+        self,
+        cmd: StrPath | list[StrPath],
+        cwd: StrPath | None = None,
+        check_returncode: bool = True,
+        log_in_real_time: bool | None = None,
+        timeout: float | None = None,
+        **kwargs: t.Any,
+    ) -> str:
+        """Run a command asynchronously.
+
+        This method will also prefix the VCS command bin_name. By default runs
+        using the cwd of the repo.
+
+        Parameters
+        ----------
+        cmd : str | list[str]
+            Command and arguments to run
+        cwd : str | Path, optional
+            Working directory, defaults to self.path
+        check_returncode : bool, default True
+            Raise on non-zero exit code
+        log_in_real_time : bool, optional
+            Stream output to callback
+        timeout : float, optional
+            Timeout in seconds
+
+        Returns
+        -------
+        str
+            Combined stdout/stderr output
+        """
+        if cwd is None:
+            cwd = getattr(self, "path", None)
+
+        if isinstance(cmd, list):
+            full_cmd = [self.bin_name, *[str(c) for c in cmd]]
+        else:
+            full_cmd = [self.bin_name, str(cmd)]
+
+        should_log = log_in_real_time or self.log_in_real_time or False
+
+        return await async_run(
+            full_cmd,
+            callback=self.progress_callback if should_log else None,
+            check_returncode=check_returncode,
+            cwd=cwd,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    def ensure_dir(self, *args: t.Any, **kwargs: t.Any) -> bool:
+        """Assure destination path exists. If not, create directories.
+
+        Note: This is synchronous as it's just filesystem operations.
+        """
+        if self.path.exists():
+            return True
+
+        if not self.path.parent.exists():
+            self.path.parent.mkdir(parents=True)
+
+        if not self.path.exists():
+            self.log.debug(
+                f"Project directory for {self.repo_name} does not exist @ {self.path}",
+            )
+            self.path.mkdir(parents=True)
+
+        return True
+
+    async def update_repo(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Pull latest changes from remote repository."""
+        raise NotImplementedError
+
+    async def obtain(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Checkout initial VCS repository from remote repository."""
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        """Representation of async VCS management object."""
+        return f"<{self.__class__.__name__} {self.repo_name}>"

--- a/src/libvcs/sync/_async/git.py
+++ b/src/libvcs/sync/_async/git.py
@@ -1,0 +1,549 @@
+"""Async tool to manage a local git clone from an external git repository.
+
+Async equivalent of :mod:`libvcs.sync.git`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import typing as t
+
+from libvcs import exc
+from libvcs._internal.async_run import AsyncProgressCallbackProtocol
+from libvcs._internal.types import StrPath
+from libvcs.cmd._async.git import AsyncGit
+from libvcs.sync._async.base import AsyncBaseSync
+from libvcs.sync.base import VCSLocation, convert_pip_url as base_convert_pip_url
+from libvcs.sync.git import (
+    GitRemote,
+    GitRemoteOriginMissing,
+    GitRemoteRefNotFound,
+    GitRemotesArgs,
+    GitRemoteSetError,
+    GitStatus,
+    GitSyncRemoteDict,
+)
+
+
+def convert_pip_url(pip_url: str) -> VCSLocation:
+    """Convert pip-style URL to a VCSLocation.
+
+    Prefixes stub URLs like 'user@hostname:user/repo.git' with 'ssh://'.
+    """
+    if "://" not in pip_url:
+        assert "file:" not in pip_url
+        pip_url = pip_url.replace("git+", "git+ssh://")
+        url, rev = base_convert_pip_url(pip_url)
+        url = url.replace("ssh://", "")
+    elif "github.com:" in pip_url:
+        msg = (
+            "Repo {} is malformatted, please use the convention {} for "
+            "ssh / private GitHub repositories.".format(
+                pip_url,
+                "git+https://github.com/username/repo.git",
+            )
+        )
+        raise exc.LibVCSException(msg)
+    else:
+        url, rev = base_convert_pip_url(pip_url)
+
+    return VCSLocation(url=url, rev=rev)
+
+
+class AsyncGitSync(AsyncBaseSync):
+    """Async tool to manage a local git clone from an external git repository.
+
+    Async equivalent of :class:`~libvcs.sync.git.GitSync`.
+
+    Examples
+    --------
+    >>> async def example():
+    ...     url = f'file://{create_git_remote_repo()}'
+    ...     repo_path = tmp_path / 'git_sync_repo'
+    ...     repo = AsyncGitSync(url=url, path=repo_path)
+    ...     await repo.obtain()
+    ...     return (repo_path / '.git').exists()
+    >>> asyncio.run(example())
+    True
+    """
+
+    bin_name = "git"
+    schemes = ("git+http", "git+https", "git+file")
+    cmd: AsyncGit
+    _remotes: GitSyncRemoteDict
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        path: StrPath,
+        remotes: GitRemotesArgs = None,
+        progress_callback: AsyncProgressCallbackProtocol | None = None,
+        **kwargs: t.Any,
+    ) -> None:
+        """Initialize async git repository manager.
+
+        Parameters
+        ----------
+        url : str
+            URL of the repository
+        path : str | Path
+            Local path for the repository
+        remotes : dict, optional
+            Additional remotes to configure
+        progress_callback : AsyncProgressCallbackProtocol, optional
+            Async callback for progress updates
+        """
+        self.git_shallow = kwargs.pop("git_shallow", False)
+        self.tls_verify = kwargs.pop("tls_verify", False)
+
+        self._remotes: GitSyncRemoteDict
+
+        if remotes is None:
+            self._remotes = {
+                "origin": GitRemote(name="origin", fetch_url=url, push_url=url),
+            }
+        elif isinstance(remotes, dict):
+            self._remotes = {}
+            for remote_name, remote_url in remotes.items():
+                if isinstance(remote_url, str):
+                    self._remotes[remote_name] = GitRemote(
+                        name=remote_name,
+                        fetch_url=remote_url,
+                        push_url=remote_url,
+                    )
+                elif isinstance(remote_url, dict):
+                    self._remotes[remote_name] = GitRemote(
+                        fetch_url=remote_url["fetch_url"],
+                        push_url=remote_url["push_url"],
+                        name=remote_name,
+                    )
+                elif isinstance(remote_url, GitRemote):
+                    self._remotes[remote_name] = remote_url
+
+        if url and "origin" not in self._remotes:
+            self._remotes["origin"] = GitRemote(
+                name="origin",
+                fetch_url=url,
+                push_url=url,
+            )
+
+        super().__init__(
+            url=url, path=path, progress_callback=progress_callback, **kwargs
+        )
+
+        self.cmd = AsyncGit(path=path, progress_callback=self.progress_callback)
+
+        origin = (
+            self._remotes.get("origin")
+            if "origin" in self._remotes
+            else next(iter(self._remotes.items()))[1]
+        )
+        if origin is None:
+            raise GitRemoteOriginMissing(remotes=list(self._remotes.keys()))
+        self.url = self.chomp_protocol(origin.fetch_url)
+
+    @classmethod
+    def from_pip_url(cls, pip_url: str, **kwargs: t.Any) -> AsyncGitSync:
+        """Clone a git repository from a pip-style URL."""
+        url, rev = convert_pip_url(pip_url)
+        return cls(url=url, rev=rev, **kwargs)
+
+    @staticmethod
+    def chomp_protocol(url: str) -> str:
+        """Remove VCS protocol prefix from URL.
+
+        Parameters
+        ----------
+        url : str
+            URL possibly with git+ prefix
+
+        Returns
+        -------
+        str
+            URL without git+ prefix
+        """
+        if url.startswith("git+"):
+            return url[4:]
+        return url
+
+    async def get_revision(self) -> str:
+        """Return current revision. Initial repositories return 'initial'."""
+        try:
+            return await self.cmd.rev_parse(
+                verify=True, args="HEAD", check_returncode=True
+            )
+        except exc.CommandError:
+            return "initial"
+
+    async def obtain(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Retrieve the repository, clone if doesn't exist."""
+        self.ensure_dir()
+
+        url = self.url
+
+        self.log.info("Cloning.")
+        await self.cmd.clone(
+            url=url,
+            progress=True,
+            depth=1 if self.git_shallow else None,
+            config={"http.sslVerify": False} if self.tls_verify else None,
+            log_in_real_time=True,
+        )
+
+        self.log.info("Initializing submodules.")
+        await self.cmd.submodule.init(log_in_real_time=True)
+        await self.cmd.submodule.update(
+            init=True,
+            recursive=True,
+            log_in_real_time=True,
+        )
+
+        await self.set_remotes(overwrite=True)
+
+    async def update_repo(
+        self,
+        set_remotes: bool = False,
+        *args: t.Any,
+        **kwargs: t.Any,
+    ) -> None:
+        """Pull latest changes from git remote."""
+        self.ensure_dir()
+
+        if not pathlib.Path(self.path / ".git").is_dir():
+            await self.obtain()
+            await self.update_repo(set_remotes=set_remotes)
+            return
+
+        if set_remotes:
+            await self.set_remotes(overwrite=True)
+
+        # Get requested revision or tag
+        url, git_tag = self.url, getattr(self, "rev", None)
+
+        if not git_tag:
+            self.log.debug("No git revision set, defaulting to origin/master")
+            symref = await self.cmd.symbolic_ref(name="HEAD", short=True)
+            git_tag = symref.rstrip() if symref else "origin/master"
+        self.log.debug("git_tag: %s", git_tag)
+
+        self.log.info("Updating to '%s'.", git_tag)
+
+        # Get head sha
+        try:
+            head_sha = await self.cmd.rev_list(
+                commit="HEAD",
+                max_count=1,
+                check_returncode=True,
+            )
+        except exc.CommandError:
+            self.log.exception("Failed to get the hash for HEAD")
+            return
+
+        self.log.debug("head_sha: %s", head_sha)
+
+        # Check if it's a remote ref
+        show_ref_output = await self.cmd.show_ref(
+            pattern=git_tag, check_returncode=False
+        )
+        self.log.debug("show_ref_output: %s", show_ref_output)
+        is_remote_ref = "remotes" in show_ref_output
+        self.log.debug("is_remote_ref: %s", is_remote_ref)
+
+        # Get remote name
+        git_remote_name = await self.get_current_remote_name()
+
+        if f"refs/remotes/{git_tag}" in show_ref_output:
+            m = re.match(
+                r"^[0-9a-f]{40} refs/remotes/"
+                r"(?P<git_remote_name>[^/]+)/"
+                r"(?P<git_tag>.+)$",
+                show_ref_output,
+                re.MULTILINE,
+            )
+            if m is None:
+                raise GitRemoteRefNotFound(git_tag=git_tag, ref_output=show_ref_output)
+            git_remote_name = m.group("git_remote_name")
+            git_tag = m.group("git_tag")
+        self.log.debug("git_remote_name: %s", git_remote_name)
+        self.log.debug("git_tag: %s", git_tag)
+
+        # Get tag sha
+        try:
+            error_code = 0
+            tag_sha = await self.cmd.rev_list(
+                commit=git_remote_name + "/" + git_tag if is_remote_ref else git_tag,
+                max_count=1,
+            )
+        except exc.CommandError as e:
+            error_code = e.returncode if e.returncode is not None else 0
+            tag_sha = ""
+        self.log.debug("tag_sha: %s", tag_sha)
+
+        # Is the hash checkout out what we want?
+        somethings_up = (error_code, is_remote_ref, tag_sha != head_sha)
+        if all(not x for x in somethings_up):
+            self.log.info("Already up-to-date.")
+            return
+
+        try:
+            await self.cmd.fetch(log_in_real_time=True, check_returncode=True)
+        except exc.CommandError:
+            self.log.exception("Failed to fetch repository '%s'", url)
+            return
+
+        if is_remote_ref:
+            # Check if stash is needed
+            try:
+                process = await self.cmd.status(porcelain=True, untracked_files="no")
+            except exc.CommandError:
+                self.log.exception("Failed to get the status")
+                return
+            need_stash = len(process) > 0
+
+            # Stash changes if needed
+            if need_stash:
+                git_stash_save_options = "--quiet"
+                try:
+                    await self.cmd.stash.save(message=git_stash_save_options)
+                except exc.CommandError:
+                    self.log.exception("Failed to stash changes")
+
+            # Checkout the remote branch
+            try:
+                await self.cmd.checkout(branch=git_tag)
+            except exc.CommandError:
+                self.log.exception("Failed to checkout tag: '%s'", git_tag)
+                return
+
+            # Rebase changes from the remote branch
+            try:
+                await self.cmd.rebase(upstream=git_remote_name + "/" + git_tag)
+            except exc.CommandError as e:
+                if any(msg in str(e) for msg in ["invalid_upstream", "Aborting"]):
+                    self.log.exception("Invalid upstream remote. Rebase aborted.")
+                else:
+                    # Rebase failed: Restore previous state
+                    await self.cmd.rebase(abort=True)
+                    if need_stash:
+                        await self.cmd.stash.pop(index=True, quiet=True)
+
+                    self.log.exception(
+                        f"\nFailed to rebase in: '{self.path}'.\n"
+                        "You will have to resolve the conflicts manually",
+                    )
+                    return
+
+            if need_stash:
+                try:
+                    await self.cmd.stash.pop(index=True, quiet=True)
+                except exc.CommandError:
+                    # Stash pop --index failed: Try again dropping the index
+                    await self.cmd.reset(hard=True, quiet=True)
+                    try:
+                        await self.cmd.stash.pop(quiet=True)
+                    except exc.CommandError:
+                        # Stash pop failed: Restore previous state
+                        await self.cmd.reset(pathspec=head_sha, hard=True, quiet=True)
+                        await self.cmd.stash.pop(index=True, quiet=True)
+                        self.log.exception(
+                            f"\nFailed to rebase in: '{self.path}'.\n"
+                            "You will have to resolve the conflicts manually",
+                        )
+                        return
+
+        else:
+            try:
+                await self.cmd.checkout(branch=git_tag)
+            except exc.CommandError:
+                self.log.exception("Failed to checkout tag: '%s'", git_tag)
+                return
+
+        await self.cmd.submodule.update(
+            recursive=True, init=True, log_in_real_time=True
+        )
+
+    async def set_remotes(self, overwrite: bool = False) -> None:
+        """Apply remotes in local repository to match configuration."""
+        remotes = self._remotes
+        if isinstance(remotes, dict):
+            for remote_name, git_remote_repo in remotes.items():
+                existing_remote = await self.remote(remote_name)
+                if isinstance(git_remote_repo, GitRemote):
+                    if (
+                        not existing_remote
+                        or existing_remote.fetch_url != git_remote_repo.fetch_url
+                    ):
+                        await self.set_remote(
+                            name=remote_name,
+                            url=git_remote_repo.fetch_url,
+                            overwrite=overwrite,
+                        )
+                        existing_remote = await self.remote(remote_name)
+                    if git_remote_repo.push_url and (
+                        not existing_remote
+                        or existing_remote.push_url != git_remote_repo.push_url
+                    ):
+                        await self.set_remote(
+                            name=remote_name,
+                            url=git_remote_repo.push_url,
+                            push=True,
+                            overwrite=overwrite,
+                        )
+                elif (
+                    not existing_remote
+                    or existing_remote.fetch_url != git_remote_repo.fetch_url
+                ):
+                    await self.set_remote(
+                        name=remote_name,
+                        url=git_remote_repo.fetch_url,
+                        overwrite=overwrite,
+                    )
+
+    async def remotes_get(self) -> GitSyncRemoteDict:
+        """Return remotes like git remote -v.
+
+        Returns
+        -------
+        dict
+            Dictionary of remote names to GitRemote objects
+        """
+        remotes: GitSyncRemoteDict = {}
+
+        ret = await self.cmd.remotes.ls()
+        for remote_name in ret:
+            remote_name = remote_name.strip()
+            if not remote_name:
+                continue
+            try:
+                remote_output = await self.cmd.remotes.show(
+                    name=remote_name,
+                    verbose=True,
+                )
+            except exc.CommandError:
+                self.log.exception("Failed to get remote info for %s", remote_name)
+                continue
+
+            # Parse remote output
+            fetch_url = ""
+            push_url = ""
+            for line in remote_output.splitlines():
+                line = line.strip()
+                if "(fetch)" in line:
+                    fetch_url = line.replace("(fetch)", "").strip()
+                elif "(push)" in line:
+                    push_url = line.replace("(push)", "").strip()
+
+            remotes[remote_name] = GitRemote(
+                name=remote_name,
+                fetch_url=fetch_url,
+                push_url=push_url,
+            )
+
+        return remotes
+
+    async def remote(self, name: str) -> GitRemote | None:
+        """Get a specific remote by name.
+
+        Parameters
+        ----------
+        name : str
+            Remote name
+
+        Returns
+        -------
+        GitRemote | None
+            Remote info or None if not found
+        """
+        remotes = await self.remotes_get()
+        return remotes.get(name)
+
+    async def set_remote(
+        self,
+        *,
+        name: str,
+        url: str,
+        push: bool = False,
+        overwrite: bool = False,
+    ) -> None:
+        """Set or add a remote.
+
+        Parameters
+        ----------
+        name : str
+            Remote name
+        url : str
+            Remote URL
+        push : bool
+            Set push URL instead of fetch URL
+        overwrite : bool
+            Overwrite existing remote
+        """
+        existing_remotes = await self.cmd.remotes.ls()
+
+        if name in existing_remotes:
+            if push:
+                # Set push URL using git remote set-url --push
+                await self.cmd.run(["remote", "set-url", "--push", name, url])
+            elif overwrite:
+                await self.cmd.run(["remote", "set-url", name, url])
+        else:
+            await self.cmd.remotes.add(name=name, url=url)
+
+        # Verify
+        remote = await self.remote(name)
+        if not remote:
+            raise GitRemoteSetError(remote_name=name)
+
+    async def get_current_remote_name(self) -> str:
+        """Get the current remote name.
+
+        Returns
+        -------
+        str
+            Remote name (defaults to 'origin')
+        """
+        try:
+            # Try to get the upstream remote
+            branch = await self.cmd.symbolic_ref(name="HEAD", short=True)
+            branch = branch.strip()
+            if branch:
+                # Get the remote for this branch
+                try:
+                    remote = await self.cmd.run(
+                        ["config", f"branch.{branch}.remote"],
+                        check_returncode=False,
+                    )
+                    if remote.strip():
+                        return remote.strip()
+                except exc.CommandError:
+                    pass
+        except exc.CommandError:
+            pass
+        return "origin"
+
+    async def get_git_version(self) -> str:
+        """Return git version.
+
+        Returns
+        -------
+        str
+            Git version string
+        """
+        return await self.cmd.version()
+
+    async def status(self) -> GitStatus:
+        """Return GitStatus with parsed git status information.
+
+        Returns
+        -------
+        GitStatus
+            Parsed git status information
+        """
+        output = await self.cmd.status(short=True, branch=True, porcelain="2")
+        return GitStatus.from_stdout(output)

--- a/src/libvcs/sync/_async/hg.py
+++ b/src/libvcs/sync/_async/hg.py
@@ -1,0 +1,111 @@
+"""Async tool to manage a local hg (Mercurial) working copy from a repository.
+
+Async equivalent of :mod:`libvcs.sync.hg`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import typing as t
+
+from libvcs._internal.async_run import AsyncProgressCallbackProtocol
+from libvcs._internal.types import StrPath
+from libvcs.cmd._async.hg import AsyncHg
+from libvcs.sync._async.base import AsyncBaseSync
+
+
+class AsyncHgSync(AsyncBaseSync):
+    """Async tool to manage a local hg (Mercurial) repository cloned from a remote one.
+
+    Async equivalent of :class:`~libvcs.sync.hg.HgSync`.
+
+    Examples
+    --------
+    >>> async def example():
+    ...     url = f'file://{create_hg_remote_repo()}'
+    ...     repo_path = tmp_path / 'hg_sync_repo'
+    ...     repo = AsyncHgSync(url=url, path=repo_path)
+    ...     await repo.obtain()
+    ...     return (repo_path / '.hg').exists()
+    >>> asyncio.run(example())
+    True
+    """
+
+    bin_name = "hg"
+    schemes = ("hg", "hg+http", "hg+https", "hg+file")
+    cmd: AsyncHg
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        path: StrPath,
+        progress_callback: AsyncProgressCallbackProtocol | None = None,
+        **kwargs: t.Any,
+    ) -> None:
+        """Initialize async Mercurial repository manager.
+
+        Parameters
+        ----------
+        url : str
+            URL of the Mercurial repository
+        path : str | Path
+            Local path for the repository
+        progress_callback : AsyncProgressCallbackProtocol, optional
+            Async callback for progress updates
+        """
+        super().__init__(
+            url=url, path=path, progress_callback=progress_callback, **kwargs
+        )
+
+        self.cmd = AsyncHg(path=path, progress_callback=self.progress_callback)
+
+    async def obtain(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Clone and update a Mercurial repository to this location asynchronously.
+
+        Async equivalent of :meth:`~libvcs.sync.hg.HgSync.obtain`.
+        """
+        self.ensure_dir()
+
+        self.log.info("Cloning.")
+        await self.cmd.clone(
+            no_update=True,
+            quiet=True,
+            url=self.url,
+            log_in_real_time=True,
+        )
+        await self.cmd.update(
+            quiet=True,
+            check_returncode=True,
+            log_in_real_time=True,
+        )
+
+    async def get_revision(self) -> str:
+        """Get latest revision of this mercurial repository asynchronously.
+
+        Async equivalent of :meth:`~libvcs.sync.hg.HgSync.get_revision`.
+
+        Returns
+        -------
+        str
+            Current revision number
+        """
+        return await self.run(["parents", "--template={rev}"])
+
+    async def update_repo(self, *args: t.Any, **kwargs: t.Any) -> None:
+        """Pull changes from remote Mercurial repository asynchronously.
+
+        Async equivalent of :meth:`~libvcs.sync.hg.HgSync.update_repo`.
+        """
+        self.ensure_dir()
+
+        if not pathlib.Path(self.path / ".hg").exists():
+            await self.obtain()
+            await self.update_repo()
+        else:
+            await self.cmd.update()
+            await self.cmd.pull(update=True)

--- a/src/libvcs/sync/_async/svn.py
+++ b/src/libvcs/sync/_async/svn.py
@@ -1,0 +1,269 @@
+"""Async tool to manage a local SVN (Subversion) working copy from a repository.
+
+Async equivalent of :mod:`libvcs.sync.svn`.
+
+Note
+----
+This is an internal API not covered by versioning policy.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pathlib
+import re
+import typing as t
+
+from libvcs._internal.async_run import AsyncProgressCallbackProtocol
+from libvcs._internal.types import StrPath
+from libvcs.cmd._async.svn import AsyncSvn
+from libvcs.sync._async.base import AsyncBaseSync
+from libvcs.sync.svn import SvnUrlRevFormattingError
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncSvnSync(AsyncBaseSync):
+    """Async tool to manage a local SVN working copy from a SVN repository.
+
+    Async equivalent of :class:`~libvcs.sync.svn.SvnSync`.
+
+    Examples
+    --------
+    >>> async def example():
+    ...     url = f'file://{create_svn_remote_repo()}'
+    ...     repo_path = tmp_path / 'svn_sync_repo'
+    ...     repo = AsyncSvnSync(url=url, path=repo_path)
+    ...     await repo.obtain()
+    ...     return (repo_path / '.svn').exists()
+    >>> asyncio.run(example())
+    True
+    """
+
+    bin_name = "svn"
+    schemes = ("svn", "svn+ssh", "svn+http", "svn+https", "svn+svn")
+    cmd: AsyncSvn
+
+    def __init__(
+        self,
+        *,
+        url: str,
+        path: StrPath,
+        progress_callback: AsyncProgressCallbackProtocol | None = None,
+        **kwargs: t.Any,
+    ) -> None:
+        """Initialize async SVN working copy manager.
+
+        Parameters
+        ----------
+        url : str
+            URL of the SVN repository
+        path : str | Path
+            Local path for the working copy
+        progress_callback : AsyncProgressCallbackProtocol, optional
+            Async callback for progress updates
+        username : str, optional
+            Username for SVN authentication
+        password : str, optional
+            Password for SVN authentication
+        svn_trust_cert : bool, optional
+            Trust the SVN server certificate, default False
+        """
+        self.svn_trust_cert = kwargs.pop("svn_trust_cert", False)
+        self.username = kwargs.get("username")
+        self.password = kwargs.get("password")
+        self.rev = kwargs.get("rev")
+
+        super().__init__(
+            url=url, path=path, progress_callback=progress_callback, **kwargs
+        )
+
+        self.cmd = AsyncSvn(path=path, progress_callback=self.progress_callback)
+
+    async def obtain(
+        self, quiet: bool | None = None, *args: t.Any, **kwargs: t.Any
+    ) -> None:
+        """Check out a working copy from a SVN repository asynchronously.
+
+        Async equivalent of :meth:`~libvcs.sync.svn.SvnSync.obtain`.
+
+        Parameters
+        ----------
+        quiet : bool, optional
+            Suppress output
+        """
+        url, rev = self.url, self.rev
+
+        if rev is not None:
+            kwargs["revision"] = rev
+        if self.svn_trust_cert:
+            kwargs["trust_server_cert"] = True
+
+        await self.cmd.checkout(
+            url=url,
+            username=self.username,
+            password=self.password,
+            non_interactive=True,
+            quiet=True,
+            check_returncode=True,
+            **kwargs,
+        )
+
+    async def get_revision_file(self, location: str) -> int:
+        """Return revision for a file asynchronously.
+
+        Async equivalent of :meth:`~libvcs.sync.svn.SvnSync.get_revision_file`.
+
+        Parameters
+        ----------
+        location : str
+            Path to the file
+
+        Returns
+        -------
+        int
+            Revision number
+        """
+        current_rev = await self.cmd.info(target=location)
+
+        INI_RE = re.compile(r"^([^:]+):\s+(\S.*)$", re.MULTILINE)
+
+        info_list = INI_RE.findall(current_rev)
+        return int(dict(info_list)["Revision"])
+
+    async def get_revision(self, location: str | None = None) -> int:
+        """Return maximum revision for all files under a given location asynchronously.
+
+        Async equivalent of :meth:`~libvcs.sync.svn.SvnSync.get_revision`.
+
+        Parameters
+        ----------
+        location : str, optional
+            Path to check, defaults to self.url
+
+        Returns
+        -------
+        int
+            Maximum revision number
+        """
+        if not location:
+            location = self.url
+
+        if pathlib.Path(location).exists() and not pathlib.Path(location).is_dir():
+            return await self.get_revision_file(location)
+
+        # Note: taken from setuptools.command.egg_info
+        revision = 0
+
+        for base, dirs, _files in os.walk(location):
+            if ".svn" not in dirs:
+                dirs[:] = []
+                continue  # no sense walking uncontrolled subdirs
+            dirs.remove(".svn")
+            entries_fn = pathlib.Path(base) / ".svn" / "entries"
+            if not entries_fn.exists():
+                # FIXME: should we warn?
+                continue
+
+            dirurl, localrev = await self._get_svn_url_rev(base)
+
+            if base == location:
+                assert dirurl is not None
+                base = dirurl + "/"  # save the root url
+            elif not dirurl or not dirurl.startswith(base):
+                dirs[:] = []
+                continue  # not part of the same svn tree, skip it
+            revision = max(revision, localrev)
+        return revision
+
+    async def update_repo(
+        self,
+        dest: str | None = None,
+        *args: t.Any,
+        **kwargs: t.Any,
+    ) -> None:
+        """Fetch changes from SVN repository to local working copy asynchronously.
+
+        Async equivalent of :meth:`~libvcs.sync.svn.SvnSync.update_repo`.
+
+        Parameters
+        ----------
+        dest : str, optional
+            Destination path (unused, for API compatibility)
+        """
+        self.ensure_dir()
+        if pathlib.Path(self.path / ".svn").exists():
+            await self.cmd.checkout(
+                url=self.url,
+                username=self.username,
+                password=self.password,
+                non_interactive=True,
+                quiet=True,
+                check_returncode=True,
+                **kwargs,
+            )
+        else:
+            await self.obtain()
+            await self.update_repo()
+
+    async def _get_svn_url_rev(self, location: str) -> tuple[str | None, int]:
+        """Get SVN URL and revision from a working copy location asynchronously.
+
+        Async equivalent of :meth:`~libvcs.sync.svn.SvnSync._get_svn_url_rev`.
+
+        Parameters
+        ----------
+        location : str
+            Path to the working copy
+
+        Returns
+        -------
+        tuple[str | None, int]
+            Repository URL and revision number
+        """
+        svn_xml_url_re = re.compile(r'url="([^"]+)"')
+        svn_rev_re = re.compile(r'committed-rev="(\d+)"')
+        svn_info_xml_rev_re = re.compile(r'\s*revision="(\d+)"')
+        svn_info_xml_url_re = re.compile(r"<url>(.*)</url>")
+
+        entries_path = pathlib.Path(location) / ".svn" / "entries"
+        if entries_path.exists():
+            with entries_path.open() as f:
+                data = f.read()
+        else:  # subversion >= 1.7 does not have the 'entries' file
+            data = ""
+
+        url = None
+        if data.startswith(("8", "9", "10")):
+            entries = list(map(str.splitlines, data.split("\n\x0c\n")))
+            del entries[0][0]  # get rid of the '8'
+            url = entries[0][3]
+            revs = [int(d[9]) for d in entries if len(d) > 9 and d[9]] + [0]
+        elif data.startswith("<?xml"):
+            match = svn_xml_url_re.search(data)
+            if not match:
+                raise SvnUrlRevFormattingError(data=data)
+            url = match.group(1)  # get repository URL
+            revs = [int(m.group(1)) for m in svn_rev_re.finditer(data)] + [0]
+        else:
+            try:
+                # Note that using get_remote_call_options is not necessary here
+                # because `svn info` is being run against a local directory.
+                # We don't need to worry about making sure interactive mode
+                # is being used to prompt for passwords, because passwords
+                # are only potentially needed for remote server requests.
+                xml = await AsyncSvn(path=pathlib.Path(location).parent).info(
+                    target=pathlib.Path(location),
+                    xml=True,
+                )
+                match = svn_info_xml_url_re.search(xml)
+                assert match is not None
+                url = match.group(1)
+                revs = [int(m.group(1)) for m in svn_info_xml_rev_re.finditer(xml)]
+            except Exception:
+                url, revs = None, []
+
+        rev = max(revs) if revs else 0
+
+        return url, rev

--- a/tests/_internal/test_async_run.py
+++ b/tests/_internal/test_async_run.py
@@ -1,0 +1,262 @@
+"""Tests for libvcs._internal.async_run."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import typing as t
+from pathlib import Path
+
+import pytest
+
+from libvcs._internal.async_run import (
+    AsyncProgressCallbackProtocol,
+    async_run,
+    wrap_sync_callback,
+)
+from libvcs.exc import CommandError, CommandTimeoutError
+
+
+class RunFixture(t.NamedTuple):
+    """Test fixture for async_run()."""
+
+    test_id: str
+    args: list[str]
+    kwargs: dict[str, t.Any]
+    expected_output: str | None
+    should_raise: bool
+
+
+RUN_FIXTURES = [
+    RunFixture(
+        test_id="echo_simple",
+        args=["echo", "hello"],
+        kwargs={},
+        expected_output="hello",
+        should_raise=False,
+    ),
+    RunFixture(
+        test_id="echo_multiline",
+        args=["echo", "line1\nline2"],
+        kwargs={},
+        expected_output="line1\nline2",
+        should_raise=False,
+    ),
+    RunFixture(
+        test_id="true_command",
+        args=["true"],
+        kwargs={},
+        expected_output="",
+        should_raise=False,
+    ),
+    RunFixture(
+        test_id="false_no_check",
+        args=["false"],
+        kwargs={"check_returncode": False},
+        expected_output="",
+        should_raise=False,
+    ),
+    RunFixture(
+        test_id="false_with_check",
+        args=["false"],
+        kwargs={"check_returncode": True},
+        expected_output=None,
+        should_raise=True,
+    ),
+]
+
+
+class TestAsyncRun:
+    """Tests for async_run function."""
+
+    @pytest.mark.parametrize(
+        list(RunFixture._fields),
+        RUN_FIXTURES,
+        ids=[f.test_id for f in RUN_FIXTURES],
+    )
+    @pytest.mark.asyncio
+    async def test_run(
+        self,
+        test_id: str,
+        args: list[str],
+        kwargs: dict[str, t.Any],
+        expected_output: str | None,
+        should_raise: bool,
+    ) -> None:
+        """Test async_run() with various commands."""
+        if should_raise:
+            with pytest.raises(CommandError):
+                await async_run(args, **kwargs)
+        else:
+            output = await async_run(args, **kwargs)
+            if expected_output is not None:
+                assert output == expected_output
+
+    @pytest.mark.asyncio
+    async def test_run_with_cwd(self, tmp_path: Path) -> None:
+        """Test async_run() uses specified working directory."""
+        output = await async_run(["pwd"], cwd=tmp_path)
+        assert output == str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_run_with_timeout(self) -> None:
+        """Test async_run() respects timeout."""
+        with pytest.raises(CommandTimeoutError):
+            await async_run(["sleep", "10"], timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_run_timeout_error_attributes(self) -> None:
+        """Test CommandTimeoutError has expected attributes."""
+        with pytest.raises(CommandTimeoutError) as exc_info:
+            await async_run(["sleep", "10"], timeout=0.1)
+
+        assert exc_info.value.returncode == -1
+        assert "timed out" in exc_info.value.output
+
+    @pytest.mark.asyncio
+    async def test_run_command_error_attributes(self) -> None:
+        """Test CommandError has expected attributes."""
+        with pytest.raises(CommandError) as exc_info:
+            await async_run(["false"], check_returncode=True)
+
+        assert exc_info.value.returncode == 1
+
+    @pytest.mark.asyncio
+    async def test_run_with_callback(self) -> None:
+        """Test async_run() calls progress callback."""
+        progress_output: list[str] = []
+        timestamps: list[datetime.datetime] = []
+
+        async def callback(output: str, timestamp: datetime.datetime) -> None:
+            progress_output.append(output)
+            timestamps.append(timestamp)
+
+        # Use a command that writes to stderr
+        await async_run(
+            ["sh", "-c", "echo stderr_line >&2"],
+            callback=callback,
+            check_returncode=True,
+        )
+
+        # Should have received stderr output + final \r
+        assert len(progress_output) >= 1
+        assert any("stderr_line" in p for p in progress_output)
+        # Final \r is sent
+        assert progress_output[-1] == "\r"
+
+    @pytest.mark.asyncio
+    async def test_run_callback_receives_timestamps(self) -> None:
+        """Test callback receives valid datetime timestamps."""
+        timestamps: list[datetime.datetime] = []
+
+        async def callback(output: str, timestamp: datetime.datetime) -> None:
+            timestamps.append(timestamp)
+
+        await async_run(
+            ["sh", "-c", "echo line >&2"],
+            callback=callback,
+        )
+
+        assert len(timestamps) >= 1
+        for ts in timestamps:
+            assert isinstance(ts, datetime.datetime)
+
+    @pytest.mark.asyncio
+    async def test_run_stderr_on_error(self) -> None:
+        """Test stderr content is returned on command error."""
+        output = await async_run(
+            ["sh", "-c", "echo error_msg >&2; exit 1"],
+            check_returncode=False,
+        )
+        assert "error_msg" in output
+
+    @pytest.mark.asyncio
+    async def test_run_concurrent(self) -> None:
+        """Test running multiple commands concurrently."""
+
+        async def run_echo(i: int) -> str:
+            return await async_run(["echo", str(i)])
+
+        results = await asyncio.gather(*[run_echo(i) for i in range(5)])
+
+        assert len(results) == 5
+        for i, result in enumerate(results):
+            assert result == str(i)
+
+
+class TestWrapSyncCallback:
+    """Tests for wrap_sync_callback helper."""
+
+    @pytest.mark.asyncio
+    async def test_wrap_sync_callback(self) -> None:
+        """Test wrap_sync_callback creates working async wrapper."""
+        calls: list[tuple[str, datetime.datetime]] = []
+
+        def sync_cb(output: str, timestamp: datetime.datetime) -> None:
+            calls.append((output, timestamp))
+
+        async_cb = wrap_sync_callback(sync_cb)
+
+        # Verify it's a valid async callback
+        now = datetime.datetime.now()
+        await async_cb("test", now)
+
+        assert len(calls) == 1
+        assert calls[0] == ("test", now)
+
+    @pytest.mark.asyncio
+    async def test_wrap_sync_callback_type(self) -> None:
+        """Test wrapped callback conforms to protocol."""
+
+        def sync_cb(output: str, timestamp: datetime.datetime) -> None:
+            pass
+
+        async_cb = wrap_sync_callback(sync_cb)
+
+        # Type check: should be usable where AsyncProgressCallbackProtocol expected
+        callback: AsyncProgressCallbackProtocol = async_cb
+        await callback("test", datetime.datetime.now())
+
+
+class TestAsyncProgressCallbackProtocol:
+    """Tests for AsyncProgressCallbackProtocol."""
+
+    @pytest.mark.asyncio
+    async def test_protocol_implementation(self) -> None:
+        """Test that a function can implement the protocol."""
+        received: list[str] = []
+
+        async def my_callback(output: str, timestamp: datetime.datetime) -> None:
+            received.append(output)
+
+        # Use as protocol type
+        cb: AsyncProgressCallbackProtocol = my_callback
+        await cb("hello", datetime.datetime.now())
+
+        assert received == ["hello"]
+
+
+class TestArgsToList:
+    """Tests for _args_to_list helper."""
+
+    @pytest.mark.asyncio
+    async def test_string_arg(self) -> None:
+        """Test single string argument."""
+        output = await async_run("echo")
+        assert output == ""
+
+    @pytest.mark.asyncio
+    async def test_path_arg(self, tmp_path: Path) -> None:
+        """Test Path argument."""
+        test_script = tmp_path / "test.sh"
+        test_script.write_text("#!/bin/sh\necho working")
+        test_script.chmod(0o755)
+
+        output = await async_run(test_script)
+        assert output == "working"
+
+    @pytest.mark.asyncio
+    async def test_bytes_arg(self) -> None:
+        """Test bytes argument."""
+        output = await async_run([b"echo", b"bytes_test"])
+        assert output == "bytes_test"

--- a/tests/_internal/test_async_subprocess.py
+++ b/tests/_internal/test_async_subprocess.py
@@ -1,0 +1,234 @@
+"""Tests for libvcs._internal.async_subprocess."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import typing as t
+from pathlib import Path
+
+import pytest
+
+from libvcs._internal.async_subprocess import (
+    AsyncCompletedProcess,
+    AsyncSubprocessCommand,
+)
+
+
+class RunFixture(t.NamedTuple):
+    """Test fixture for AsyncSubprocessCommand.run()."""
+
+    test_id: str
+    args: list[str]
+    kwargs: dict[str, t.Any]
+    expected_stdout: str | None
+    expected_returncode: int
+
+
+RUN_FIXTURES = [
+    RunFixture(
+        test_id="echo_text",
+        args=["echo", "hello"],
+        kwargs={"text": True},
+        expected_stdout="hello\n",
+        expected_returncode=0,
+    ),
+    RunFixture(
+        test_id="echo_bytes",
+        args=["echo", "hello"],
+        kwargs={"text": False},
+        expected_stdout=None,  # bytes comparison handled separately
+        expected_returncode=0,
+    ),
+    RunFixture(
+        test_id="true_command",
+        args=["true"],
+        kwargs={},
+        expected_stdout=None,
+        expected_returncode=0,
+    ),
+    RunFixture(
+        test_id="false_command",
+        args=["false"],
+        kwargs={"check": False},
+        expected_stdout=None,
+        expected_returncode=1,
+    ),
+]
+
+
+class TestAsyncCompletedProcess:
+    """Tests for AsyncCompletedProcess dataclass."""
+
+    def test_init(self) -> None:
+        """Test basic initialization."""
+        result = AsyncCompletedProcess(
+            args=["echo", "test"],
+            returncode=0,
+            stdout="test\n",
+            stderr="",
+        )
+        assert result.args == ["echo", "test"]
+        assert result.returncode == 0
+        assert result.stdout == "test\n"
+        assert result.stderr == ""
+
+    def test_check_returncode_success(self) -> None:
+        """Test check_returncode with zero exit code."""
+        result = AsyncCompletedProcess(
+            args=["true"],
+            returncode=0,
+        )
+        # Should not raise
+        result.check_returncode()
+
+    def test_check_returncode_failure(self) -> None:
+        """Test check_returncode with non-zero exit code."""
+        result = AsyncCompletedProcess(
+            args=["false"],
+            returncode=1,
+            stdout="",
+            stderr="error",
+        )
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            result.check_returncode()
+        assert exc_info.value.returncode == 1
+        assert exc_info.value.cmd == ["false"]
+
+
+class TestAsyncSubprocessCommand:
+    """Tests for AsyncSubprocessCommand."""
+
+    def test_init(self) -> None:
+        """Test basic initialization."""
+        cmd = AsyncSubprocessCommand(args=["echo", "hello"])
+        assert cmd.args == ["echo", "hello"]
+        assert cmd.cwd is None
+        assert cmd.env is None
+
+    def test_init_with_cwd(self, tmp_path: Path) -> None:
+        """Test initialization with working directory."""
+        cmd = AsyncSubprocessCommand(args=["pwd"], cwd=tmp_path)
+        assert cmd.cwd == tmp_path
+
+    def test_args_as_list_sequence(self) -> None:
+        """Test _args_as_list with sequence of strings."""
+        cmd = AsyncSubprocessCommand(args=["echo", "hello", "world"])
+        assert cmd._args_as_list() == ["echo", "hello", "world"]
+
+    def test_args_as_list_single_string(self) -> None:
+        """Test _args_as_list with single string."""
+        cmd = AsyncSubprocessCommand(args="echo")
+        assert cmd._args_as_list() == ["echo"]
+
+    def test_args_as_list_path(self, tmp_path: Path) -> None:
+        """Test _args_as_list with Path object."""
+        cmd = AsyncSubprocessCommand(args=tmp_path)
+        assert cmd._args_as_list() == [str(tmp_path)]
+
+    @pytest.mark.parametrize(
+        list(RunFixture._fields),
+        RUN_FIXTURES,
+        ids=[f.test_id for f in RUN_FIXTURES],
+    )
+    @pytest.mark.asyncio
+    async def test_run(
+        self,
+        test_id: str,
+        args: list[str],
+        kwargs: dict[str, t.Any],
+        expected_stdout: str | None,
+        expected_returncode: int,
+    ) -> None:
+        """Test run() with various commands."""
+        cmd = AsyncSubprocessCommand(args=args)
+        result = await cmd.run(**kwargs)
+
+        assert result.returncode == expected_returncode
+        if expected_stdout is not None:
+            assert result.stdout == expected_stdout
+
+    @pytest.mark.asyncio
+    async def test_run_bytes_output(self) -> None:
+        """Test run() returns bytes when text=False."""
+        cmd = AsyncSubprocessCommand(args=["echo", "hello"])
+        result = await cmd.run(text=False)
+
+        assert isinstance(result.stdout, bytes)
+        assert result.stdout == b"hello\n"
+
+    @pytest.mark.asyncio
+    async def test_run_with_input(self) -> None:
+        """Test run() with stdin input."""
+        cmd = AsyncSubprocessCommand(args=["cat"])
+        result = await cmd.run(input="hello", text=True)
+
+        assert result.stdout == "hello"
+        assert result.returncode == 0
+
+    @pytest.mark.asyncio
+    async def test_run_with_check_raises(self) -> None:
+        """Test run() with check=True raises on non-zero exit."""
+        cmd = AsyncSubprocessCommand(args=["false"])
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            await cmd.run(check=True)
+        assert exc_info.value.returncode == 1
+
+    @pytest.mark.asyncio
+    async def test_run_with_timeout(self) -> None:
+        """Test run() respects timeout."""
+        cmd = AsyncSubprocessCommand(args=["sleep", "10"])
+        with pytest.raises(asyncio.TimeoutError):
+            await cmd.run(timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_run_with_cwd(self, tmp_path: Path) -> None:
+        """Test run() uses specified working directory."""
+        cmd = AsyncSubprocessCommand(args=["pwd"], cwd=tmp_path)
+        result = await cmd.run(text=True)
+
+        assert result.stdout is not None
+        assert result.stdout.strip() == str(tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_check_output(self) -> None:
+        """Test check_output() returns stdout."""
+        cmd = AsyncSubprocessCommand(args=["echo", "hello"])
+        output = await cmd.check_output(text=True)
+
+        assert output == "hello\n"
+
+    @pytest.mark.asyncio
+    async def test_check_output_raises_on_error(self) -> None:
+        """Test check_output() raises on non-zero exit."""
+        cmd = AsyncSubprocessCommand(args=["false"])
+        with pytest.raises(subprocess.CalledProcessError):
+            await cmd.check_output()
+
+    @pytest.mark.asyncio
+    async def test_wait(self) -> None:
+        """Test wait() returns exit code."""
+        cmd = AsyncSubprocessCommand(args=["true"])
+        returncode = await cmd.wait()
+
+        assert returncode == 0
+
+    @pytest.mark.asyncio
+    async def test_wait_with_timeout(self) -> None:
+        """Test wait() respects timeout."""
+        cmd = AsyncSubprocessCommand(args=["sleep", "10"])
+        with pytest.raises(asyncio.TimeoutError):
+            await cmd.wait(timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_concurrent_commands(self) -> None:
+        """Test running multiple commands concurrently."""
+        commands = [AsyncSubprocessCommand(args=["echo", str(i)]) for i in range(5)]
+
+        results = await asyncio.gather(*[cmd.run(text=True) for cmd in commands])
+
+        assert len(results) == 5
+        for i, result in enumerate(results):
+            assert result.stdout is not None
+            assert result.stdout.strip() == str(i)
+            assert result.returncode == 0

--- a/tests/cmd/_async/__init__.py
+++ b/tests/cmd/_async/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for async command classes."""
+
+from __future__ import annotations

--- a/tests/cmd/_async/test_git.py
+++ b/tests/cmd/_async/test_git.py
@@ -1,0 +1,645 @@
+"""Tests for libvcs.cmd._async.git."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import typing as t
+from pathlib import Path
+
+import pytest
+
+from libvcs.cmd._async.git import (
+    AsyncGit,
+)
+from libvcs.pytest_plugin import CreateRepoPytestFixtureFn
+from libvcs.sync.git import GitSync
+
+
+class RunFixture(t.NamedTuple):
+    """Test fixture for AsyncGit.run()."""
+
+    test_id: str
+    args: list[str]
+    kwargs: dict[str, t.Any]
+    expected_in_output: str | None
+
+
+RUN_FIXTURES = [
+    RunFixture(
+        test_id="version",
+        args=["version"],
+        kwargs={},
+        expected_in_output="git version",
+    ),
+    RunFixture(
+        test_id="help_short",
+        args=["--help"],
+        kwargs={},
+        expected_in_output="usage: git",
+    ),
+]
+
+
+class TestAsyncGit:
+    """Tests for AsyncGit class."""
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test AsyncGit initialization."""
+        git = AsyncGit(path=tmp_path)
+        assert git.path == tmp_path
+        assert git.progress_callback is None
+
+    def test_repr(self, tmp_path: Path) -> None:
+        """Test AsyncGit repr."""
+        git = AsyncGit(path=tmp_path)
+        assert "AsyncGit" in repr(git)
+        assert str(tmp_path) in repr(git)
+
+    @pytest.mark.parametrize(
+        list(RunFixture._fields),
+        RUN_FIXTURES,
+        ids=[f.test_id for f in RUN_FIXTURES],
+    )
+    @pytest.mark.asyncio
+    async def test_run(
+        self,
+        test_id: str,
+        args: list[str],
+        kwargs: dict[str, t.Any],
+        expected_in_output: str | None,
+        tmp_path: Path,
+    ) -> None:
+        """Test AsyncGit.run() with various commands."""
+        git = AsyncGit(path=tmp_path)
+        output = await git.run(args, **kwargs)
+        if expected_in_output is not None:
+            assert expected_in_output in output
+
+    @pytest.mark.asyncio
+    async def test_run_with_config(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test AsyncGit.run() with config options."""
+        git = AsyncGit(path=git_repo.path)
+        output = await git.run(
+            ["config", "user.name"],
+            config={"user.name": "Test User"},
+        )
+        # Config is passed, command runs
+        assert output is not None
+
+    @pytest.mark.asyncio
+    async def test_version(self, tmp_path: Path) -> None:
+        """Test AsyncGit.version()."""
+        git = AsyncGit(path=tmp_path)
+        version = await git.version()
+        assert "git version" in version
+
+
+class TestAsyncGitClone:
+    """Tests for AsyncGit.clone()."""
+
+    @pytest.mark.asyncio
+    async def test_clone_basic(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test basic clone operation."""
+        remote_repo = create_git_remote_repo()
+        clone_path = tmp_path / "cloned_repo"
+        git = AsyncGit(path=clone_path)
+
+        await git.clone(url=f"file://{remote_repo}")
+
+        assert clone_path.exists()
+        assert (clone_path / ".git").exists()
+
+    @pytest.mark.asyncio
+    async def test_clone_with_depth(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test shallow clone with depth parameter."""
+        remote_repo = create_git_remote_repo()
+        clone_path = tmp_path / "shallow_repo"
+        git = AsyncGit(path=clone_path)
+
+        await git.clone(url=f"file://{remote_repo}", depth=1)
+
+        assert clone_path.exists()
+        assert (clone_path / ".git").exists()
+        # Note: .git/shallow file only exists if there's more history to truncate
+        # For a single-commit repo, depth=1 still works but no shallow file is created
+
+    @pytest.mark.asyncio
+    async def test_clone_make_parents(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test clone creates parent directories."""
+        remote_repo = create_git_remote_repo()
+        clone_path = tmp_path / "deep" / "nested" / "repo"
+        git = AsyncGit(path=clone_path)
+
+        await git.clone(url=f"file://{remote_repo}", make_parents=True)
+
+        assert clone_path.exists()
+
+
+class TestAsyncGitFetch:
+    """Tests for AsyncGit.fetch()."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_basic(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test basic fetch."""
+        git = AsyncGit(path=git_repo.path)
+        # Fetch from origin
+        output = await git.fetch()
+        # Should succeed (might be empty if nothing to fetch)
+        assert output is not None
+
+
+class TestAsyncGitStatus:
+    """Tests for AsyncGit.status()."""
+
+    @pytest.mark.asyncio
+    async def test_status_clean(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test status on clean repo."""
+        git = AsyncGit(path=git_repo.path)
+        status = await git.status()
+        # Clean repo status
+        assert status is not None
+
+    @pytest.mark.asyncio
+    async def test_status_porcelain(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test porcelain status format."""
+        git = AsyncGit(path=git_repo.path)
+        status = await git.status(porcelain=True)
+        # Clean repo should have empty porcelain output
+        assert status == ""
+
+    @pytest.mark.asyncio
+    async def test_status_with_changes(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test status with uncommitted changes."""
+        # Create a new file
+        new_file = git_repo.path / "new_file.txt"
+        new_file.write_text("test content")
+
+        git = AsyncGit(path=git_repo.path)
+        status = await git.status(porcelain=True)
+        # Should show untracked file
+        assert "new_file.txt" in status
+
+
+class TestAsyncGitCheckout:
+    """Tests for AsyncGit.checkout()."""
+
+    @pytest.mark.asyncio
+    async def test_checkout_branch(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test checkout existing branch."""
+        git = AsyncGit(path=git_repo.path)
+        # Get current branch first
+        current = await git.symbolic_ref(name="HEAD", short=True)
+        # Checkout same branch (should succeed)
+        await git.checkout(branch=current.strip())
+
+
+class TestAsyncGitRevParse:
+    """Tests for AsyncGit.rev_parse()."""
+
+    @pytest.mark.asyncio
+    async def test_rev_parse_head(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test rev-parse HEAD."""
+        git = AsyncGit(path=git_repo.path)
+        sha = await git.rev_parse(args="HEAD", verify=True)
+        assert sha.strip()
+        assert len(sha.strip()) == 40  # Full SHA-1
+
+    @pytest.mark.asyncio
+    async def test_rev_parse_show_toplevel(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test rev-parse --show-toplevel."""
+        git = AsyncGit(path=git_repo.path)
+        toplevel = await git.rev_parse(show_toplevel=True)
+        assert toplevel.strip() == str(git_repo.path)
+
+
+class TestAsyncGitSymbolicRef:
+    """Tests for AsyncGit.symbolic_ref()."""
+
+    @pytest.mark.asyncio
+    async def test_symbolic_ref_head(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test symbolic-ref HEAD."""
+        git = AsyncGit(path=git_repo.path)
+        ref = await git.symbolic_ref(name="HEAD")
+        assert "refs/heads/" in ref
+
+
+class TestAsyncGitRemoteManager:
+    """Tests for AsyncGitRemoteManager."""
+
+    @pytest.mark.asyncio
+    async def test_ls_remotes(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test listing remotes."""
+        git = AsyncGit(path=git_repo.path)
+        remotes = await git.remotes.ls()
+        assert "origin" in remotes
+
+    @pytest.mark.asyncio
+    async def test_add_and_remove_remote(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test adding and removing a remote."""
+        git = AsyncGit(path=git_repo.path)
+
+        # Add a new remote
+        await git.remotes.add(name="test_remote", url="file:///dev/null")
+
+        # Verify it's in the list
+        remotes = await git.remotes.ls()
+        assert "test_remote" in remotes
+
+        # Remove it
+        await git.remotes.remove(name="test_remote")
+
+        # Verify it's gone
+        remotes = await git.remotes.ls()
+        assert "test_remote" not in remotes
+
+    @pytest.mark.asyncio
+    async def test_get_url(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test getting remote URL."""
+        git = AsyncGit(path=git_repo.path)
+        url = await git.remotes.get_url(name="origin")
+        assert url.strip()  # Should have some URL
+
+
+class TestAsyncGitStashCmd:
+    """Tests for AsyncGitStashCmd."""
+
+    @pytest.mark.asyncio
+    async def test_stash_ls_empty(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test listing empty stash."""
+        git = AsyncGit(path=git_repo.path)
+        stashes = await git.stash.ls()
+        # Empty stash list
+        assert stashes == ""
+
+    @pytest.mark.asyncio
+    async def test_stash_save_no_changes(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test stash save with no changes."""
+        git = AsyncGit(path=git_repo.path)
+        # No changes to stash - command runs but reports nothing to save
+        output = await git.stash.save(message="Test stash")
+        assert "No local changes to save" in output
+
+
+class TestAsyncGitReset:
+    """Tests for AsyncGit.reset()."""
+
+    @pytest.mark.asyncio
+    async def test_reset_soft(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test soft reset."""
+        git = AsyncGit(path=git_repo.path)
+        # Create a file and commit it
+        test_file = git_repo.path / "reset_test.txt"
+        test_file.write_text("initial content")
+        await git.run(["add", "reset_test.txt"])
+        await git.run(["commit", "-m", "test commit"])
+
+        # Soft reset to HEAD~1
+        output = await git.reset(pathspec="HEAD~1", soft=True)
+        # Soft reset should succeed
+        assert output is not None
+
+    @pytest.mark.asyncio
+    async def test_reset_mixed(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test mixed reset (default mode)."""
+        git = AsyncGit(path=git_repo.path)
+        # Create and stage a file
+        test_file = git_repo.path / "staged_file.txt"
+        test_file.write_text("staged content")
+        await git.run(["add", "staged_file.txt"])
+
+        # Mixed reset to unstage
+        output = await git.reset(mixed=True)
+        assert output is not None
+
+        # Verify file is unstaged
+        status = await git.status(porcelain=True)
+        assert "??" in status  # Untracked marker
+
+    @pytest.mark.asyncio
+    async def test_reset_hard(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test hard reset discards changes."""
+        git = AsyncGit(path=git_repo.path)
+        # Modify a tracked file
+        test_file = git_repo.path / "hard_reset.txt"
+        test_file.write_text("original")
+        await git.run(["add", "hard_reset.txt"])
+        await git.run(["commit", "-m", "add file"])
+
+        # Modify the file
+        test_file.write_text("modified")
+
+        # Hard reset should discard changes
+        await git.reset(pathspec="HEAD", hard=True)
+
+        # File should be back to original
+        assert test_file.read_text() == "original"
+
+    @pytest.mark.asyncio
+    async def test_reset_quiet(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test reset with quiet flag."""
+        git = AsyncGit(path=git_repo.path)
+        output = await git.reset(quiet=True)
+        # Quiet mode should suppress output
+        assert output == ""
+
+    @pytest.mark.asyncio
+    async def test_reset_pathspec_list(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test reset with pathspec as list."""
+        git = AsyncGit(path=git_repo.path)
+        # Create and stage multiple files
+        file1 = git_repo.path / "file1.txt"
+        file2 = git_repo.path / "file2.txt"
+        file1.write_text("content1")
+        file2.write_text("content2")
+        await git.run(["add", "file1.txt", "file2.txt"])
+
+        # Reset specific files using list
+        output = await git.reset(pathspec=["file1.txt", "file2.txt"])
+        assert output is not None
+
+
+class TestAsyncGitRebase:
+    """Tests for AsyncGit.rebase()."""
+
+    @pytest.mark.asyncio
+    async def test_rebase_upstream(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test rebase onto upstream branch."""
+        git = AsyncGit(path=git_repo.path)
+        # Get current branch
+        current = await git.symbolic_ref(name="HEAD", short=True)
+        current_branch = current.strip()
+
+        # Create a feature branch
+        await git.run(["checkout", "-b", "feature"])
+        test_file = git_repo.path / "feature_file.txt"
+        test_file.write_text("feature content")
+        await git.run(["add", "feature_file.txt"])
+        await git.run(["commit", "-m", "feature commit"])
+
+        # Rebase onto original branch (trivial rebase - already up to date)
+        output = await git.rebase(upstream=current_branch)
+        assert output is not None
+
+    @pytest.mark.asyncio
+    async def test_rebase_onto(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test rebase with onto option."""
+        git = AsyncGit(path=git_repo.path)
+        # Get initial commit
+        initial = await git.rev_parse(args="HEAD", verify=True)
+
+        # Create branch and commit
+        await git.run(["checkout", "-b", "onto_test"])
+        test_file = git_repo.path / "onto_file.txt"
+        test_file.write_text("onto content")
+        await git.run(["add", "onto_file.txt"])
+        await git.run(["commit", "-m", "onto commit"])
+
+        # Rebase onto initial commit (trivial case)
+        output = await git.rebase(onto=initial.strip(), upstream=initial.strip())
+        assert output is not None
+
+    @pytest.mark.asyncio
+    async def test_rebase_abort_no_rebase(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test rebase abort when no rebase in progress."""
+        git = AsyncGit(path=git_repo.path)
+        # Abort with no rebase in progress should fail
+        output = await git.rebase(abort=True, check_returncode=False)
+        # Returns error message or empty depending on git version
+        assert output is not None
+
+    @pytest.mark.asyncio
+    async def test_rebase_quiet(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Test rebase with quiet flag."""
+        # Create a fresh git repo with initial commit
+        repo_path = tmp_path / "rebase_quiet_repo"
+        repo_path.mkdir()
+        git = AsyncGit(path=repo_path)
+        await git.run(["init"])
+        await git.run(["config", "user.email", "test@test.com"])
+        await git.run(["config", "user.name", "Test User"])
+
+        # Create initial commit
+        test_file = repo_path / "initial.txt"
+        test_file.write_text("initial content")
+        await git.run(["add", "initial.txt"])
+        await git.run(["commit", "-m", "initial"])
+
+        # Rebase onto HEAD (trivial - no changes)
+        head = await git.rev_parse(args="HEAD", verify=True)
+        output = await git.rebase(upstream=head.strip(), quiet=True)
+        # Quiet mode reduces output
+        assert output is not None
+
+
+class TestAsyncGitSubmoduleCmd:
+    """Tests for AsyncGitSubmoduleCmd."""
+
+    @pytest.mark.asyncio
+    async def test_submodule_init_no_submodules(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test submodule init on repo without submodules."""
+        git = AsyncGit(path=git_repo.path)
+        # Should succeed even without submodules
+        output = await git.submodule.init()
+        assert output == ""
+
+    @pytest.mark.asyncio
+    async def test_submodule_update_no_submodules(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test submodule update on repo without submodules."""
+        git = AsyncGit(path=git_repo.path)
+        # Should succeed even without submodules
+        output = await git.submodule.update()
+        assert output == ""
+
+    @pytest.mark.asyncio
+    async def test_submodule_update_with_init(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test submodule update with init flag."""
+        git = AsyncGit(path=git_repo.path)
+        output = await git.submodule.update(init=True)
+        assert output == ""
+
+    @pytest.mark.asyncio
+    async def test_submodule_update_recursive(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test submodule update with recursive flag."""
+        git = AsyncGit(path=git_repo.path)
+        output = await git.submodule.update(recursive=True)
+        assert output == ""
+
+    @pytest.mark.asyncio
+    async def test_submodule_update_force(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test submodule update with force flag."""
+        git = AsyncGit(path=git_repo.path)
+        output = await git.submodule.update(force=True)
+        assert output == ""
+
+    @pytest.mark.asyncio
+    async def test_submodule_update_combined_flags(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test submodule update with combined flags."""
+        git = AsyncGit(path=git_repo.path)
+        output = await git.submodule.update(init=True, recursive=True, force=True)
+        assert output == ""
+
+
+class TestAsyncGitConcurrency:
+    """Tests for concurrent AsyncGit operations."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_status_calls(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test multiple concurrent status calls."""
+        git = AsyncGit(path=git_repo.path)
+
+        async def get_status() -> str:
+            return await git.status(porcelain=True)
+
+        results = await asyncio.gather(*[get_status() for _ in range(5)])
+
+        assert len(results) == 5
+        for result in results:
+            assert result == ""  # Clean repo
+
+    @pytest.mark.asyncio
+    async def test_concurrent_rev_parse(
+        self,
+        git_repo: GitSync,
+    ) -> None:
+        """Test multiple concurrent rev-parse calls."""
+        git = AsyncGit(path=git_repo.path)
+
+        async def get_head() -> str:
+            return await git.rev_parse(args="HEAD", verify=True)
+
+        results = await asyncio.gather(*[get_head() for _ in range(5)])
+
+        assert len(results) == 5
+        # All should return the same SHA
+        first_sha = results[0].strip()
+        for result in results[1:]:
+            assert result.strip() == first_sha
+
+
+class TestAsyncGitWithCallback:
+    """Tests for AsyncGit with progress callbacks."""
+
+    @pytest.mark.asyncio
+    async def test_clone_with_callback(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test clone with progress callback."""
+        progress_output: list[str] = []
+
+        async def progress_cb(output: str, timestamp: datetime.datetime) -> None:
+            progress_output.append(output)
+
+        remote_repo = create_git_remote_repo()
+        clone_path = tmp_path / "callback_repo"
+        git = AsyncGit(path=clone_path, progress_callback=progress_cb)
+
+        await git.clone(url=f"file://{remote_repo}", log_in_real_time=True)
+
+        assert clone_path.exists()
+        # Progress callback should have been called
+        # (may be empty for local clone, but mechanism works)

--- a/tests/cmd/_async/test_git.py
+++ b/tests/cmd/_async/test_git.py
@@ -12,7 +12,7 @@ import pytest
 from libvcs.cmd._async.git import (
     AsyncGit,
 )
-from libvcs.pytest_plugin import CreateRepoPytestFixtureFn
+from libvcs.pytest_plugin import CreateRepoFn
 from libvcs.sync.git import GitSync
 
 
@@ -105,7 +105,7 @@ class TestAsyncGitClone:
     async def test_clone_basic(
         self,
         tmp_path: Path,
-        create_git_remote_repo: CreateRepoPytestFixtureFn,
+        create_git_remote_repo: CreateRepoFn,
     ) -> None:
         """Test basic clone operation."""
         remote_repo = create_git_remote_repo()
@@ -121,7 +121,7 @@ class TestAsyncGitClone:
     async def test_clone_with_depth(
         self,
         tmp_path: Path,
-        create_git_remote_repo: CreateRepoPytestFixtureFn,
+        create_git_remote_repo: CreateRepoFn,
     ) -> None:
         """Test shallow clone with depth parameter."""
         remote_repo = create_git_remote_repo()
@@ -139,7 +139,7 @@ class TestAsyncGitClone:
     async def test_clone_make_parents(
         self,
         tmp_path: Path,
-        create_git_remote_repo: CreateRepoPytestFixtureFn,
+        create_git_remote_repo: CreateRepoFn,
     ) -> None:
         """Test clone creates parent directories."""
         remote_repo = create_git_remote_repo()
@@ -626,7 +626,7 @@ class TestAsyncGitWithCallback:
     async def test_clone_with_callback(
         self,
         tmp_path: Path,
-        create_git_remote_repo: CreateRepoPytestFixtureFn,
+        create_git_remote_repo: CreateRepoFn,
     ) -> None:
         """Test clone with progress callback."""
         progress_output: list[str] = []

--- a/tests/cmd/_async/test_hg.py
+++ b/tests/cmd/_async/test_hg.py
@@ -1,0 +1,179 @@
+"""Tests for libvcs.cmd._async.hg."""
+
+from __future__ import annotations
+
+import typing as t
+from pathlib import Path
+
+import pytest
+
+from libvcs.cmd._async.hg import AsyncHg
+from libvcs.pytest_plugin import CreateRepoPytestFixtureFn
+
+
+class RunFixture(t.NamedTuple):
+    """Test fixture for AsyncHg.run()."""
+
+    test_id: str
+    args: list[str]
+    kwargs: dict[str, t.Any]
+    expected_in_output: str | None
+
+
+RUN_FIXTURES = [
+    RunFixture(
+        test_id="version",
+        args=["version"],
+        kwargs={},
+        expected_in_output="Mercurial",
+    ),
+    RunFixture(
+        test_id="help_short",
+        args=["--help"],
+        kwargs={},
+        expected_in_output="Mercurial",
+    ),
+]
+
+
+class TestAsyncHg:
+    """Tests for AsyncHg class."""
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test AsyncHg initialization."""
+        hg = AsyncHg(path=tmp_path)
+        assert hg.path == tmp_path
+        assert hg.progress_callback is None
+
+    def test_repr(self, tmp_path: Path) -> None:
+        """Test AsyncHg repr."""
+        hg = AsyncHg(path=tmp_path)
+        assert "AsyncHg" in repr(hg)
+        assert str(tmp_path) in repr(hg)
+
+    @pytest.mark.parametrize(
+        list(RunFixture._fields),
+        RUN_FIXTURES,
+        ids=[f.test_id for f in RUN_FIXTURES],
+    )
+    @pytest.mark.asyncio
+    async def test_run(
+        self,
+        test_id: str,
+        args: list[str],
+        kwargs: dict[str, t.Any],
+        expected_in_output: str | None,
+        tmp_path: Path,
+    ) -> None:
+        """Test AsyncHg.run() with various commands."""
+        hg = AsyncHg(path=tmp_path)
+        output = await hg.run(args, **kwargs)
+        if expected_in_output is not None:
+            assert expected_in_output in output
+
+
+class TestAsyncHgClone:
+    """Tests for AsyncHg.clone()."""
+
+    @pytest.mark.asyncio
+    async def test_clone_basic(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test basic clone operation."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "cloned_repo"
+
+        hg = AsyncHg(path=repo_path)
+        await hg.clone(url=f"file://{remote_repo}")
+
+        assert repo_path.exists()
+        assert (repo_path / ".hg").exists()
+
+    @pytest.mark.asyncio
+    async def test_clone_quiet(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test clone with quiet flag."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "quiet_repo"
+
+        hg = AsyncHg(path=repo_path)
+        await hg.clone(url=f"file://{remote_repo}", quiet=True)
+
+        assert repo_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_clone_no_update(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test clone with no_update flag."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "noupdate_repo"
+
+        hg = AsyncHg(path=repo_path)
+        await hg.clone(url=f"file://{remote_repo}", no_update=True)
+
+        assert repo_path.exists()
+        assert (repo_path / ".hg").exists()
+
+
+class TestAsyncHgUpdate:
+    """Tests for AsyncHg.update()."""
+
+    @pytest.mark.asyncio
+    async def test_update_basic(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test basic update operation."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "update_repo"
+
+        hg = AsyncHg(path=repo_path)
+        await hg.clone(url=f"file://{remote_repo}")
+        output = await hg.update()
+
+        assert "files" in output or "0 files" in output
+
+
+class TestAsyncHgPull:
+    """Tests for AsyncHg.pull()."""
+
+    @pytest.mark.asyncio
+    async def test_pull_basic(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test basic pull operation."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "pull_repo"
+
+        hg = AsyncHg(path=repo_path)
+        await hg.clone(url=f"file://{remote_repo}")
+        output = await hg.pull()
+
+        assert "no changes found" in output or "pulling from" in output
+
+    @pytest.mark.asyncio
+    async def test_pull_with_update(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test pull with update flag."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "pull_update_repo"
+
+        hg = AsyncHg(path=repo_path)
+        await hg.clone(url=f"file://{remote_repo}")
+        output = await hg.pull(update=True)
+
+        assert output is not None

--- a/tests/cmd/_async/test_hg.py
+++ b/tests/cmd/_async/test_hg.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from libvcs.cmd._async.hg import AsyncHg
-from libvcs.pytest_plugin import CreateRepoPytestFixtureFn
+from libvcs.pytest_plugin import CreateRepoFn
 
 
 class RunFixture(t.NamedTuple):
@@ -79,7 +79,7 @@ class TestAsyncHgClone:
     async def test_clone_basic(
         self,
         tmp_path: Path,
-        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+        create_hg_remote_repo: CreateRepoFn,
     ) -> None:
         """Test basic clone operation."""
         remote_repo = create_hg_remote_repo()
@@ -95,7 +95,7 @@ class TestAsyncHgClone:
     async def test_clone_quiet(
         self,
         tmp_path: Path,
-        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+        create_hg_remote_repo: CreateRepoFn,
     ) -> None:
         """Test clone with quiet flag."""
         remote_repo = create_hg_remote_repo()
@@ -110,7 +110,7 @@ class TestAsyncHgClone:
     async def test_clone_no_update(
         self,
         tmp_path: Path,
-        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+        create_hg_remote_repo: CreateRepoFn,
     ) -> None:
         """Test clone with no_update flag."""
         remote_repo = create_hg_remote_repo()
@@ -130,7 +130,7 @@ class TestAsyncHgUpdate:
     async def test_update_basic(
         self,
         tmp_path: Path,
-        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+        create_hg_remote_repo: CreateRepoFn,
     ) -> None:
         """Test basic update operation."""
         remote_repo = create_hg_remote_repo()
@@ -150,7 +150,7 @@ class TestAsyncHgPull:
     async def test_pull_basic(
         self,
         tmp_path: Path,
-        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+        create_hg_remote_repo: CreateRepoFn,
     ) -> None:
         """Test basic pull operation."""
         remote_repo = create_hg_remote_repo()
@@ -166,7 +166,7 @@ class TestAsyncHgPull:
     async def test_pull_with_update(
         self,
         tmp_path: Path,
-        create_hg_remote_repo: CreateRepoPytestFixtureFn,
+        create_hg_remote_repo: CreateRepoFn,
     ) -> None:
         """Test pull with update flag."""
         remote_repo = create_hg_remote_repo()

--- a/tests/cmd/_async/test_svn.py
+++ b/tests/cmd/_async/test_svn.py
@@ -1,0 +1,168 @@
+"""Tests for libvcs.cmd._async.svn."""
+
+from __future__ import annotations
+
+import shutil
+import typing as t
+from pathlib import Path
+
+import pytest
+
+from libvcs.cmd._async.svn import AsyncSvn
+from libvcs.pytest_plugin import CreateRepoPytestFixtureFn
+
+if not shutil.which("svn"):
+    pytestmark = pytest.mark.skip(reason="svn is not available")
+
+
+class RunFixture(t.NamedTuple):
+    """Test fixture for AsyncSvn.run()."""
+
+    test_id: str
+    args: list[str]
+    kwargs: dict[str, t.Any]
+    expected_in_output: str | None
+
+
+RUN_FIXTURES = [
+    RunFixture(
+        test_id="version",
+        args=["--version"],
+        kwargs={},
+        expected_in_output="svn",
+    ),
+    RunFixture(
+        test_id="help_short",
+        args=["help"],
+        kwargs={},
+        expected_in_output="usage",
+    ),
+]
+
+
+class TestAsyncSvn:
+    """Tests for AsyncSvn class."""
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test AsyncSvn initialization."""
+        svn = AsyncSvn(path=tmp_path)
+        assert svn.path == tmp_path
+        assert svn.progress_callback is None
+
+    def test_repr(self, tmp_path: Path) -> None:
+        """Test AsyncSvn repr."""
+        svn = AsyncSvn(path=tmp_path)
+        assert "AsyncSvn" in repr(svn)
+        assert str(tmp_path) in repr(svn)
+
+    @pytest.mark.parametrize(
+        list(RunFixture._fields),
+        RUN_FIXTURES,
+        ids=[f.test_id for f in RUN_FIXTURES],
+    )
+    @pytest.mark.asyncio
+    async def test_run(
+        self,
+        test_id: str,
+        args: list[str],
+        kwargs: dict[str, t.Any],
+        expected_in_output: str | None,
+        tmp_path: Path,
+    ) -> None:
+        """Test AsyncSvn.run() with various commands."""
+        svn = AsyncSvn(path=tmp_path)
+        output = await svn.run(args, **kwargs)
+        if expected_in_output is not None:
+            assert expected_in_output in output.lower()
+
+
+class TestAsyncSvnCheckout:
+    """Tests for AsyncSvn.checkout()."""
+
+    @pytest.mark.asyncio
+    async def test_checkout_basic(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test basic checkout operation."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "checked_out_repo"
+
+        svn = AsyncSvn(path=repo_path)
+        await svn.checkout(url=f"file://{remote_repo}")
+
+        assert repo_path.exists()
+        assert (repo_path / ".svn").exists()
+
+    @pytest.mark.asyncio
+    async def test_checkout_quiet(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test checkout with quiet flag."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "quiet_repo"
+
+        svn = AsyncSvn(path=repo_path)
+        await svn.checkout(url=f"file://{remote_repo}", quiet=True)
+
+        assert repo_path.exists()
+
+
+class TestAsyncSvnUpdate:
+    """Tests for AsyncSvn.update()."""
+
+    @pytest.mark.asyncio
+    async def test_update_basic(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test basic update operation."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "update_repo"
+
+        svn = AsyncSvn(path=repo_path)
+        await svn.checkout(url=f"file://{remote_repo}")
+        output = await svn.update()
+
+        assert "revision" in output.lower() or "at revision" in output.lower()
+
+
+class TestAsyncSvnInfo:
+    """Tests for AsyncSvn.info()."""
+
+    @pytest.mark.asyncio
+    async def test_info_basic(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test basic info operation."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "info_repo"
+
+        svn = AsyncSvn(path=repo_path)
+        await svn.checkout(url=f"file://{remote_repo}")
+        output = await svn.info()
+
+        assert "URL:" in output or "url" in output.lower()
+
+    @pytest.mark.asyncio
+    async def test_info_xml(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+    ) -> None:
+        """Test info with XML output."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "info_xml_repo"
+
+        svn = AsyncSvn(path=repo_path)
+        await svn.checkout(url=f"file://{remote_repo}")
+        output = await svn.info(xml=True)
+
+        assert "<?xml" in output
+        assert "<info>" in output

--- a/tests/cmd/_async/test_svn.py
+++ b/tests/cmd/_async/test_svn.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from libvcs.cmd._async.svn import AsyncSvn
-from libvcs.pytest_plugin import CreateRepoPytestFixtureFn
+from libvcs.pytest_plugin import CreateRepoFn
 
 if not shutil.which("svn"):
     pytestmark = pytest.mark.skip(reason="svn is not available")
@@ -83,7 +83,7 @@ class TestAsyncSvnCheckout:
     async def test_checkout_basic(
         self,
         tmp_path: Path,
-        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+        create_svn_remote_repo: CreateRepoFn,
     ) -> None:
         """Test basic checkout operation."""
         remote_repo = create_svn_remote_repo()
@@ -99,7 +99,7 @@ class TestAsyncSvnCheckout:
     async def test_checkout_quiet(
         self,
         tmp_path: Path,
-        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+        create_svn_remote_repo: CreateRepoFn,
     ) -> None:
         """Test checkout with quiet flag."""
         remote_repo = create_svn_remote_repo()
@@ -118,7 +118,7 @@ class TestAsyncSvnUpdate:
     async def test_update_basic(
         self,
         tmp_path: Path,
-        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+        create_svn_remote_repo: CreateRepoFn,
     ) -> None:
         """Test basic update operation."""
         remote_repo = create_svn_remote_repo()
@@ -138,7 +138,7 @@ class TestAsyncSvnInfo:
     async def test_info_basic(
         self,
         tmp_path: Path,
-        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+        create_svn_remote_repo: CreateRepoFn,
     ) -> None:
         """Test basic info operation."""
         remote_repo = create_svn_remote_repo()
@@ -154,7 +154,7 @@ class TestAsyncSvnInfo:
     async def test_info_xml(
         self,
         tmp_path: Path,
-        create_svn_remote_repo: CreateRepoPytestFixtureFn,
+        create_svn_remote_repo: CreateRepoFn,
     ) -> None:
         """Test info with XML output."""
         remote_repo = create_svn_remote_repo()

--- a/tests/sync/_async/__init__.py
+++ b/tests/sync/_async/__init__.py
@@ -1,0 +1,3 @@
+"""Tests for async sync classes."""
+
+from __future__ import annotations

--- a/tests/sync/_async/test_git.py
+++ b/tests/sync/_async/test_git.py
@@ -1,0 +1,580 @@
+"""Tests for libvcs.sync._async.git."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from libvcs.pytest_plugin import CreateRepoFn
+from libvcs.sync._async.git import AsyncGitSync
+from libvcs.sync.git import GitRemote
+
+
+class TestAsyncGitSync:
+    """Tests for AsyncGitSync class."""
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test AsyncGitSync initialization."""
+        repo = AsyncGitSync(
+            url="https://github.com/test/repo",
+            path=tmp_path / "repo",
+        )
+        assert repo.url == "https://github.com/test/repo"
+        assert repo.path == tmp_path / "repo"
+        assert "origin" in repo._remotes
+
+    def test_init_with_remotes(self, tmp_path: Path) -> None:
+        """Test AsyncGitSync initialization with additional remotes."""
+        repo = AsyncGitSync(
+            url="https://github.com/test/repo",
+            path=tmp_path / "repo",
+            remotes={
+                "upstream": "https://github.com/upstream/repo",
+            },
+        )
+        assert "origin" in repo._remotes
+        assert "upstream" in repo._remotes
+
+    def test_repr(self, tmp_path: Path) -> None:
+        """Test AsyncGitSync repr."""
+        repo = AsyncGitSync(
+            url="https://github.com/test/repo",
+            path=tmp_path / "myrepo",
+        )
+        assert "AsyncGitSync" in repr(repo)
+        assert "myrepo" in repr(repo)
+
+    def test_chomp_protocol(self) -> None:
+        """Test chomp_protocol removes git+ prefix."""
+        assert (
+            AsyncGitSync.chomp_protocol("git+https://example.com")
+            == "https://example.com"
+        )
+        assert (
+            AsyncGitSync.chomp_protocol("https://example.com") == "https://example.com"
+        )
+
+
+class TestAsyncGitSyncObtain:
+    """Tests for AsyncGitSync.obtain()."""
+
+    @pytest.mark.asyncio
+    async def test_obtain_basic(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test basic obtain operation."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "obtained_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        assert repo_path.exists()
+        assert (repo_path / ".git").exists()
+
+    @pytest.mark.asyncio
+    async def test_obtain_shallow(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test shallow clone via obtain."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "shallow_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+            git_shallow=True,
+        )
+        await repo.obtain()
+
+        assert repo_path.exists()
+
+
+class TestAsyncGitSyncUpdateRepo:
+    """Tests for AsyncGitSync.update_repo()."""
+
+    @pytest.mark.asyncio
+    async def test_update_repo_basic(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test basic update_repo operation."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "update_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        # First obtain
+        await repo.obtain()
+
+        # Then update
+        await repo.update_repo()
+
+        assert repo_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_update_repo_obtains_if_missing(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test update_repo clones if repo doesn't exist."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "new_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        # Just update_repo without obtain first
+        await repo.update_repo()
+
+        # Should have cloned
+        assert repo_path.exists()
+        assert (repo_path / ".git").exists()
+
+
+class TestAsyncGitSyncGetRevision:
+    """Tests for AsyncGitSync.get_revision()."""
+
+    @pytest.mark.asyncio
+    async def test_get_revision(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test get_revision returns current HEAD or 'initial'."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "rev_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        revision = await repo.get_revision()
+        assert revision
+        # Either a 40-char SHA or "initial" for empty repos
+        stripped = revision.strip()
+        assert len(stripped) == 40 or stripped == "initial"
+
+
+class TestAsyncGitSyncRemotes:
+    """Tests for AsyncGitSync remote management."""
+
+    @pytest.mark.asyncio
+    async def test_remotes_get(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test remotes_get returns remotes."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "remotes_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        remotes = await repo.remotes_get()
+        assert "origin" in remotes
+        assert isinstance(remotes["origin"], GitRemote)
+
+    @pytest.mark.asyncio
+    async def test_remote_get_single(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test remote() returns single remote."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "single_remote_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        origin = await repo.remote("origin")
+        assert origin is not None
+        assert origin.name == "origin"
+
+    @pytest.mark.asyncio
+    async def test_set_remote(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test set_remote adds a new remote."""
+        remote_repo = create_git_remote_repo()
+        # Create a second remote repo to use as upstream
+        upstream_repo = create_git_remote_repo()
+        repo_path = tmp_path / "set_remote_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        # Add a new remote pointing to another valid repo
+        await repo.set_remote(name="upstream", url=f"file://{upstream_repo}")
+
+        # Verify it exists
+        upstream = await repo.remote("upstream")
+        assert upstream is not None
+        assert upstream.name == "upstream"
+
+
+class TestAsyncGitSyncStatus:
+    """Tests for AsyncGitSync.status()."""
+
+    @pytest.mark.asyncio
+    async def test_status(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test status() returns GitStatus without error."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "status_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        # Just verify status() runs without error
+        # The GitStatus parser may not find data for all repos
+        status = await repo.status()
+        from libvcs.sync.git import GitStatus
+
+        assert isinstance(status, GitStatus)
+
+
+class TestAsyncGitRepoFixture:
+    """Tests for the async_git_repo pytest fixture."""
+
+    @pytest.mark.asyncio
+    async def test_async_git_repo_fixture(
+        self,
+        async_git_repo: AsyncGitSync,
+    ) -> None:
+        """Test that async_git_repo fixture provides a working repository."""
+        # Verify the repo exists and is initialized
+        assert async_git_repo.path.exists()
+        assert (async_git_repo.path / ".git").exists()
+
+        # Verify we can perform async operations
+        revision = await async_git_repo.get_revision()
+        assert revision
+        assert len(revision.strip()) == 40  # Full SHA
+
+    @pytest.mark.asyncio
+    async def test_async_git_repo_status(
+        self,
+        async_git_repo: AsyncGitSync,
+    ) -> None:
+        """Test that status() works on fixture-provided repo."""
+        from libvcs.sync.git import GitStatus
+
+        status = await async_git_repo.status()
+        assert isinstance(status, GitStatus)
+
+    @pytest.mark.asyncio
+    async def test_async_git_repo_remotes(
+        self,
+        async_git_repo: AsyncGitSync,
+    ) -> None:
+        """Test that remotes are properly configured on fixture-provided repo."""
+        remotes = await async_git_repo.remotes_get()
+        assert "origin" in remotes
+
+
+class TestAsyncGitSyncFromPipUrl:
+    """Tests for AsyncGitSync.from_pip_url()."""
+
+    def test_from_pip_url_https(self, tmp_path: Path) -> None:
+        """Test from_pip_url with git+https URL."""
+        repo = AsyncGitSync.from_pip_url(
+            pip_url="git+https://github.com/test/repo.git",
+            path=tmp_path / "pip_repo",
+        )
+        assert repo.url == "https://github.com/test/repo.git"
+        assert repo.path == tmp_path / "pip_repo"
+
+    def test_from_pip_url_with_revision(self, tmp_path: Path) -> None:
+        """Test from_pip_url with revision specifier."""
+        repo = AsyncGitSync.from_pip_url(
+            pip_url="git+https://github.com/test/repo.git@v1.0.0",
+            path=tmp_path / "pip_repo",
+        )
+        assert repo.url == "https://github.com/test/repo.git"
+        assert repo.rev == "v1.0.0"
+
+    def test_from_pip_url_ssh(self, tmp_path: Path) -> None:
+        """Test from_pip_url with git+ssh URL."""
+        repo = AsyncGitSync.from_pip_url(
+            pip_url="git+ssh://git@github.com/test/repo.git",
+            path=tmp_path / "pip_repo",
+        )
+        assert repo.url == "ssh://git@github.com/test/repo.git"
+
+
+class TestAsyncGitSyncGetGitVersion:
+    """Tests for AsyncGitSync.get_git_version()."""
+
+    @pytest.mark.asyncio
+    async def test_get_git_version(
+        self,
+        async_git_repo: AsyncGitSync,
+    ) -> None:
+        """Test get_git_version returns version string."""
+        version = await async_git_repo.get_git_version()
+        assert "git version" in version
+
+    @pytest.mark.asyncio
+    async def test_get_git_version_format(
+        self,
+        async_git_repo: AsyncGitSync,
+    ) -> None:
+        """Test get_git_version returns expected format."""
+        version = await async_git_repo.get_git_version()
+        # Version string should contain numbers
+        import re
+
+        assert re.search(r"\d+\.\d+", version)
+
+
+class TestAsyncGitSyncUpdateRepoStash:
+    """Tests for AsyncGitSync.update_repo() stash handling."""
+
+    @pytest.mark.asyncio
+    async def test_update_repo_with_uncommitted_changes(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test update_repo with uncommitted changes triggers stash."""
+        from libvcs.pytest_plugin import git_remote_repo_single_commit_post_init
+
+        # Create remote with a commit
+        remote_repo = create_git_remote_repo(
+            remote_repo_post_init=git_remote_repo_single_commit_post_init
+        )
+        repo_path = tmp_path / "stash_test_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        # Create uncommitted changes
+        test_file = repo_path / "local_change.txt"
+        test_file.write_text("local uncommitted content")
+        await repo.cmd.run(["add", "local_change.txt"])
+
+        # Update should handle the uncommitted changes (may stash if needed)
+        # This tests the stash logic path
+        await repo.update_repo()
+
+        # Repo should still exist and be valid
+        assert repo_path.exists()
+        revision = await repo.get_revision()
+        assert revision
+
+    @pytest.mark.asyncio
+    async def test_update_repo_clean_working_tree(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test update_repo with clean working tree skips stash."""
+        from libvcs.pytest_plugin import git_remote_repo_single_commit_post_init
+
+        remote_repo = create_git_remote_repo(
+            remote_repo_post_init=git_remote_repo_single_commit_post_init
+        )
+        repo_path = tmp_path / "clean_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        # No changes - update should succeed without stash
+        await repo.update_repo()
+
+        assert repo_path.exists()
+
+
+class TestAsyncGitSyncSetRemotes:
+    """Tests for AsyncGitSync.set_remotes()."""
+
+    @pytest.mark.asyncio
+    async def test_set_remotes_overwrite_false(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test set_remotes with overwrite=False preserves existing remotes."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "set_remotes_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        # Get original origin URL
+        original_remotes = await repo.remotes_get()
+        original_origin_url = original_remotes["origin"].fetch_url
+
+        # Try to set remotes with overwrite=False
+        await repo.set_remotes(overwrite=False)
+
+        # Origin should still have same URL
+        updated_remotes = await repo.remotes_get()
+        assert updated_remotes["origin"].fetch_url == original_origin_url
+
+    @pytest.mark.asyncio
+    async def test_set_remotes_adds_new_remote(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test set_remotes adds new remotes from configuration."""
+        remote_repo = create_git_remote_repo()
+        upstream_repo = create_git_remote_repo()
+        repo_path = tmp_path / "add_remote_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+            remotes={"upstream": f"file://{upstream_repo}"},
+        )
+        await repo.obtain()
+
+        # Set remotes should add upstream
+        await repo.set_remotes(overwrite=False)
+
+        remotes = await repo.remotes_get()
+        assert "origin" in remotes
+        assert "upstream" in remotes
+
+
+class TestAsyncGitSyncGetCurrentRemoteName:
+    """Tests for AsyncGitSync.get_current_remote_name()."""
+
+    @pytest.mark.asyncio
+    async def test_get_current_remote_name_default(
+        self,
+        async_git_repo: AsyncGitSync,
+    ) -> None:
+        """Test get_current_remote_name returns origin by default."""
+        remote_name = await async_git_repo.get_current_remote_name()
+        assert remote_name == "origin"
+
+    @pytest.mark.asyncio
+    async def test_get_current_remote_name_on_detached_head(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test get_current_remote_name on detached HEAD falls back to origin."""
+        from libvcs.pytest_plugin import git_remote_repo_single_commit_post_init
+
+        remote_repo = create_git_remote_repo(
+            remote_repo_post_init=git_remote_repo_single_commit_post_init
+        )
+        repo_path = tmp_path / "detached_head_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        # Detach HEAD
+        head = await repo.cmd.rev_parse(args="HEAD", verify=True)
+        await repo.cmd.checkout(branch=head.strip(), detach=True)
+
+        # Should fall back to 'origin'
+        remote_name = await repo.get_current_remote_name()
+        assert remote_name == "origin"
+
+
+class TestAsyncGitSyncConcurrency:
+    """Tests for concurrent AsyncGitSync operations."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_obtain(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test multiple concurrent obtain operations."""
+        remote_repo = create_git_remote_repo()
+
+        async def clone_repo(i: int) -> AsyncGitSync:
+            repo_path = tmp_path / f"concurrent_repo_{i}"
+            repo = AsyncGitSync(
+                url=f"file://{remote_repo}",
+                path=repo_path,
+            )
+            await repo.obtain()
+            return repo
+
+        repos = await asyncio.gather(*[clone_repo(i) for i in range(3)])
+
+        assert len(repos) == 3
+        for repo in repos:
+            assert repo.path.exists()
+            assert (repo.path / ".git").exists()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_status_calls(
+        self,
+        tmp_path: Path,
+        create_git_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test multiple concurrent status calls on same repo."""
+        remote_repo = create_git_remote_repo()
+        repo_path = tmp_path / "concurrent_status_repo"
+
+        repo = AsyncGitSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        async def get_revision() -> str:
+            return await repo.get_revision()
+
+        results = await asyncio.gather(*[get_revision() for _ in range(5)])
+
+        assert len(results) == 5
+        # All should return the same SHA
+        first_sha = results[0].strip()
+        for result in results[1:]:
+            assert result.strip() == first_sha

--- a/tests/sync/_async/test_hg.py
+++ b/tests/sync/_async/test_hg.py
@@ -1,0 +1,148 @@
+"""Tests for libvcs.sync._async.hg."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from libvcs.pytest_plugin import CreateRepoFn
+from libvcs.sync._async.hg import AsyncHgSync
+
+
+class TestAsyncHgSync:
+    """Tests for AsyncHgSync class."""
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test AsyncHgSync initialization."""
+        repo = AsyncHgSync(
+            url="https://hg.example.com/repo",
+            path=tmp_path / "repo",
+        )
+        assert repo.url == "https://hg.example.com/repo"
+        assert repo.path == tmp_path / "repo"
+
+    def test_repr(self, tmp_path: Path) -> None:
+        """Test AsyncHgSync repr."""
+        repo = AsyncHgSync(
+            url="https://hg.example.com/repo",
+            path=tmp_path / "myrepo",
+        )
+        assert "AsyncHgSync" in repr(repo)
+        assert "myrepo" in repr(repo)
+
+
+class TestAsyncHgSyncObtain:
+    """Tests for AsyncHgSync.obtain()."""
+
+    @pytest.mark.asyncio
+    async def test_obtain_basic(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test basic obtain operation."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "obtained_repo"
+
+        repo = AsyncHgSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        assert repo_path.exists()
+        assert (repo_path / ".hg").exists()
+
+
+class TestAsyncHgSyncUpdateRepo:
+    """Tests for AsyncHgSync.update_repo()."""
+
+    @pytest.mark.asyncio
+    async def test_update_repo_basic(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test basic update_repo operation."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "update_repo"
+
+        repo = AsyncHgSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        # First obtain
+        await repo.obtain()
+
+        # Then update
+        await repo.update_repo()
+
+        assert repo_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_update_repo_obtains_if_missing(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test update_repo clones if repo doesn't exist."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "new_repo"
+
+        repo = AsyncHgSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        # Just update_repo without obtain first
+        await repo.update_repo()
+
+        # Should have cloned
+        assert repo_path.exists()
+        assert (repo_path / ".hg").exists()
+
+
+class TestAsyncHgSyncGetRevision:
+    """Tests for AsyncHgSync.get_revision()."""
+
+    @pytest.mark.asyncio
+    async def test_get_revision(
+        self,
+        tmp_path: Path,
+        create_hg_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test get_revision returns current revision."""
+        remote_repo = create_hg_remote_repo()
+        repo_path = tmp_path / "rev_repo"
+
+        repo = AsyncHgSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        revision = await repo.get_revision()
+        # Mercurial revisions are numeric (0, 1, 2, ...)
+        assert revision.strip().isdigit() or revision.strip() == ""
+
+
+class TestAsyncHgRepoFixture:
+    """Tests for the async_hg_repo pytest fixture."""
+
+    @pytest.mark.asyncio
+    async def test_async_hg_repo_fixture(
+        self,
+        async_hg_repo: AsyncHgSync,
+    ) -> None:
+        """Test that async_hg_repo fixture provides a working repository."""
+        assert async_hg_repo.path.exists()
+        assert (async_hg_repo.path / ".hg").exists()
+
+    @pytest.mark.asyncio
+    async def test_async_hg_repo_revision(
+        self,
+        async_hg_repo: AsyncHgSync,
+    ) -> None:
+        """Test async_hg_repo fixture can get revision."""
+        revision = await async_hg_repo.get_revision()
+        assert revision.strip().isdigit() or revision.strip() == ""

--- a/tests/sync/_async/test_svn.py
+++ b/tests/sync/_async/test_svn.py
@@ -1,0 +1,271 @@
+"""Tests for libvcs.sync._async.svn."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from libvcs.pytest_plugin import CreateRepoFn
+from libvcs.sync._async.svn import AsyncSvnSync
+
+if not shutil.which("svn"):
+    pytestmark = pytest.mark.skip(reason="svn is not available")
+
+
+class TestAsyncSvnSyncGetSvnUrlRev:
+    """Tests for AsyncSvnSync._get_svn_url_rev()."""
+
+    @pytest.mark.asyncio
+    async def test_get_svn_url_rev_from_working_copy(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test _get_svn_url_rev from actual working copy."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "url_rev_repo"
+
+        repo = AsyncSvnSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        # Get URL and revision from the working copy
+        url, rev = await repo._get_svn_url_rev(str(repo_path))
+
+        # URL should match the remote
+        assert url is not None
+        assert str(remote_repo) in url
+        # Revision should be 0 for empty repo
+        assert rev == 0
+
+    @pytest.mark.asyncio
+    async def test_get_svn_url_rev_nonexistent_location(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test _get_svn_url_rev with non-existent location."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "url_rev_repo"
+
+        repo = AsyncSvnSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        # Get URL and revision from non-existent path
+        url, rev = await repo._get_svn_url_rev(str(tmp_path / "nonexistent"))
+
+        # Should return None, 0 for non-existent path
+        assert url is None
+        assert rev == 0
+
+    @pytest.mark.asyncio
+    async def test_get_svn_url_rev_xml_format(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test _get_svn_url_rev with XML format entries file."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "xml_repo"
+
+        repo = AsyncSvnSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        # Create a mock XML entries file
+        entries_path = repo_path / ".svn" / "entries"
+        xml_data = f"""<?xml version="1.0" encoding="utf-8"?>
+<wc-entries xmlns="svn:">
+<entry name="" url="file://{remote_repo}" committed-rev="42"/>
+<entry name="file.txt" committed-rev="10"/>
+</wc-entries>"""
+        entries_path.write_text(xml_data)
+
+        # Parse the mock entries file
+        url, rev = await repo._get_svn_url_rev(str(repo_path))
+
+        # Should parse URL and max revision from XML
+        assert url is not None
+        assert str(remote_repo) in url
+        assert rev == 42  # max of 42 and 10
+
+
+class TestAsyncSvnSync:
+    """Tests for AsyncSvnSync class."""
+
+    def test_init(self, tmp_path: Path) -> None:
+        """Test AsyncSvnSync initialization."""
+        repo = AsyncSvnSync(
+            url="file:///path/to/repo",
+            path=tmp_path / "repo",
+        )
+        assert repo.url == "file:///path/to/repo"
+        assert repo.path == tmp_path / "repo"
+
+    def test_repr(self, tmp_path: Path) -> None:
+        """Test AsyncSvnSync repr."""
+        repo = AsyncSvnSync(
+            url="file:///path/to/repo",
+            path=tmp_path / "myrepo",
+        )
+        assert "AsyncSvnSync" in repr(repo)
+        assert "myrepo" in repr(repo)
+
+    def test_init_with_auth(self, tmp_path: Path) -> None:
+        """Test AsyncSvnSync initialization with auth credentials."""
+        repo = AsyncSvnSync(
+            url="svn://svn.example.com/repo",
+            path=tmp_path / "repo",
+            username="user",
+            password="pass",
+            svn_trust_cert=True,
+        )
+        assert repo.username == "user"
+        assert repo.password == "pass"
+        assert repo.svn_trust_cert is True
+
+
+class TestAsyncSvnSyncObtain:
+    """Tests for AsyncSvnSync.obtain()."""
+
+    @pytest.mark.asyncio
+    async def test_obtain_basic(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test basic obtain operation."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "obtained_repo"
+
+        repo = AsyncSvnSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        assert repo_path.exists()
+        assert (repo_path / ".svn").exists()
+
+
+class TestAsyncSvnSyncUpdateRepo:
+    """Tests for AsyncSvnSync.update_repo()."""
+
+    @pytest.mark.asyncio
+    async def test_update_repo_basic(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test basic update_repo operation."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "update_repo"
+
+        repo = AsyncSvnSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        # First obtain
+        await repo.obtain()
+
+        # Then update
+        await repo.update_repo()
+
+        assert repo_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_update_repo_obtains_if_missing(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test update_repo checks out if repo doesn't exist."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "new_repo"
+
+        repo = AsyncSvnSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        # Just update_repo without obtain first
+        await repo.update_repo()
+
+        # Should have checked out
+        assert repo_path.exists()
+        assert (repo_path / ".svn").exists()
+
+
+class TestAsyncSvnSyncGetRevision:
+    """Tests for AsyncSvnSync.get_revision()."""
+
+    @pytest.mark.asyncio
+    async def test_get_revision(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test get_revision returns current revision."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "rev_repo"
+
+        repo = AsyncSvnSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        revision = await repo.get_revision()
+        # SVN revisions start at 0 for empty repos
+        assert revision == 0
+
+    @pytest.mark.asyncio
+    async def test_get_revision_file(
+        self,
+        tmp_path: Path,
+        create_svn_remote_repo: CreateRepoFn,
+    ) -> None:
+        """Test get_revision_file returns file revision."""
+        remote_repo = create_svn_remote_repo()
+        repo_path = tmp_path / "rev_file_repo"
+
+        repo = AsyncSvnSync(
+            url=f"file://{remote_repo}",
+            path=repo_path,
+        )
+        await repo.obtain()
+
+        revision = await repo.get_revision_file("./")
+        # SVN revisions start at 0 for empty repos
+        assert revision == 0
+
+
+class TestAsyncSvnRepoFixture:
+    """Tests for the async_svn_repo pytest fixture."""
+
+    @pytest.mark.asyncio
+    async def test_async_svn_repo_fixture(
+        self,
+        async_svn_repo: AsyncSvnSync,
+    ) -> None:
+        """Test that async_svn_repo fixture provides a working repository."""
+        assert async_svn_repo.path.exists()
+        assert (async_svn_repo.path / ".svn").exists()
+
+    @pytest.mark.asyncio
+    async def test_async_svn_repo_revision(
+        self,
+        async_svn_repo: AsyncSvnSync,
+    ) -> None:
+        """Test async_svn_repo fixture can get revision."""
+        revision = await async_svn_repo.get_revision()
+        # SVN revisions start at 0 for empty repos
+        assert revision == 0

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -585,6 +594,7 @@ dev = [
     { name = "gp-sphinx" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
@@ -610,6 +620,7 @@ lint = [
 testing = [
     { name = "gp-libs" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
@@ -631,6 +642,7 @@ dev = [
     { name = "gp-sphinx", specifier = "==0.0.1a10" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
@@ -654,6 +666,7 @@ lint = [
 testing = [
     { name = "gp-libs" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-mock" },
     { name = "pytest-rerunfailures" },
     { name = "pytest-watcher" },
@@ -969,6 +982,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add async equivalents for all sync APIs with `Async` prefix
- `AsyncGit`, `AsyncHg`, `AsyncSvn` command classes
- `AsyncGitSync`, `AsyncHgSync`, `AsyncSvnSync` sync classes
- Async subprocess wrapper with progress callbacks
- pytest-asyncio fixtures for async testing

## New APIs
| Sync | Async |
|------|-------|
| `Git` | `AsyncGit` |
| `Hg` | `AsyncHg` |
| `Svn` | `AsyncSvn` |
| `GitSync` | `AsyncGitSync` |
| `HgSync` | `AsyncHgSync` |
| `SvnSync` | `AsyncSvnSync` |

## Test plan
- [x] Unit tests for async subprocess and run modules
- [x] Tests for all async command classes
- [x] Tests for all async sync classes
- [x] Async fixture tests
- [x] Documentation with working doctests