### PR TITLE
sync/git(fix[update_repo]): Use quiet=True for stash.save

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,12 @@ $ uv add libvcs --prerelease allow
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Bug fixes
+
+#### Fix stash.save() quiet parameter usage (#506)
+
+- Fixed `GitSync.update_repo()` to use `stash.save(quiet=True)` instead of incorrectly passing `"--quiet"` as the message parameter
+
 ## libvcs 0.40.0 (2026-04-25)
 
 ### What's new

--- a/src/libvcs/sync/git.py
+++ b/src/libvcs/sync/git.py
@@ -551,10 +551,8 @@ class GitSync(BaseSync):
             # If not in clean state, stash changes in order to be able
             # to be able to perform git pull --rebase
             if need_stash:
-                # If Git < 1.7.6, uses --quiet --all
-                git_stash_save_options = "--quiet"
                 try:
-                    process = self.cmd.stash.save(message=git_stash_save_options)
+                    process = self.cmd.stash.save(quiet=True)
                 except exc.CommandError as e:
                     self.log.exception("Failed to stash changes")
                     result.add_error("stash-save", str(e), exception=e)


### PR DESCRIPTION
## Summary
- Fixed `GitSync.update_repo()` to use `stash.save(quiet=True)` instead of incorrectly passing `"--quiet"` as the message parameter

## Problem
The code was calling `self.cmd.stash.save(message="--quiet")` which passed the string `"--quiet"` as the stash message instead of using the dedicated `quiet` parameter to suppress output.

This resulted in stashes being created with the literal message "--quiet" rather than the operation being quiet.

## Fix
Changed to `self.cmd.stash.save(quiet=True)` and removed the unused variable and outdated comment.