### PR TITLE
fix(sync): Prevent vcspull sync hangs on ref-heavy remotes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,6 +42,21 @@ the private `_ENV` type that was leaking into public signatures:
 `CreateRepoPytestFixtureFn` is renamed to `CreateRepoFn`. Update any
 `TYPE_CHECKING` imports accordingly.
 
+#### New `timeout=` keyword on subprocess runners
+
+`libvcs._internal.run.run()`, `Git.run()`, `Hg.run()`, and `Svn.run()`
+now accept `timeout`, with improved cleanup and handling of stuck
+subprocesses when the deadline fires. (#524)
+
+### Bug fixes
+
+#### Improve handling of ref-heavy remotes
+
+Large repositories (e.g. `openai/codex` at 2,400+ refs) no longer
+appear to hang during `vcspull sync` -- libvcs avoids the expensive
+ref-walking git command that was load-bearing for the URL lookup.
+(#524)
+
 ### Documentation
 
 - pytest plugin: `CreateRepoFn` and `CreateRepoPostInitFn` now render

--- a/conftest.py
+++ b/conftest.py
@@ -46,3 +46,21 @@ def setup(
     set_home: pathlib.Path,
 ) -> None:
     """Configure test fixtures for pytest."""
+
+
+@pytest.fixture
+def fast_timeout_constants(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tighten the deadline-loop spread so test wall-clock budgets stay reliable.
+
+    The two ``_TIMEOUT_*`` constants in :mod:`libvcs._internal.run` are tuned
+    for production use (0.5 s SIGTERM grace, 0.1 s selector poll). For tests
+    that intentionally fire the deadline, those defaults add up to ~0.7 s of
+    unavoidable wall-clock spread on top of the test's nominal timeout, which
+    makes upper-bound assertions fragile on loaded CI runners. This fixture
+    monkeypatches both to 0.05 s so the spread stays predictable; production
+    behaviour is unchanged.
+    """
+    from libvcs._internal import run as run_module
+
+    monkeypatch.setattr(run_module, "_TIMEOUT_KILL_GRACE_SECONDS", 0.05)
+    monkeypatch.setattr(run_module, "_TIMEOUT_POLL_INTERVAL_SECONDS", 0.05)

--- a/src/libvcs/_internal/run.py
+++ b/src/libvcs/_internal/run.py
@@ -388,7 +388,15 @@ def _wait_with_deadline(
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                _terminate_process(proc)
+                logger.warning(
+                    "subprocess deadline exceeded after %.3gs",
+                    timeout,
+                    extra={
+                        "vcs_cmd": _format_cmd_for_log(cmd),
+                        "vcs_exit_code": proc.returncode,
+                    },
+                )
+                _terminate_process(proc, cmd)
                 for stream in list(registered):
                     trailing = _drain_stream(stream)
                     if trailing:
@@ -458,7 +466,7 @@ def _join_buffer(
     return b"".join(buffers[stream])
 
 
-def _terminate_process(proc: subprocess.Popen[bytes]) -> None:
+def _terminate_process(proc: subprocess.Popen[bytes], cmd: str | list[str]) -> None:
     """Terminate ``proc`` gracefully, falling back to ``kill`` on the grace."""
     if proc.poll() is not None:
         return
@@ -469,12 +477,28 @@ def _terminate_process(proc: subprocess.Popen[bytes]) -> None:
     try:
         proc.wait(timeout=_TIMEOUT_KILL_GRACE_SECONDS)
     except subprocess.TimeoutExpired:
+        logger.debug(
+            "subprocess sigkill escalated after sigterm grace expired",
+            extra={"vcs_cmd": _format_cmd_for_log(cmd)},
+        )
         with contextlib.suppress(OSError, ProcessLookupError):
             proc.kill()
         # If the child is still unreachable after SIGKILL, bail rather than
         # block forever -- we've already signalled the user-facing timeout.
         with contextlib.suppress(subprocess.TimeoutExpired):
             proc.wait(timeout=_TIMEOUT_KILL_GRACE_SECONDS)
+        if proc.poll() is None:
+            logger.warning(
+                "subprocess sigkill did not reap; child may be leaked",
+                extra={"vcs_cmd": _format_cmd_for_log(cmd)},
+            )
+
+
+def _format_cmd_for_log(cmd: str | list[str]) -> str:
+    """Render ``cmd`` as a flat string for the ``vcs_cmd`` log extra."""
+    if isinstance(cmd, list):
+        return " ".join(cmd)
+    return cmd
 
 
 def _drain_stream(stream: t.IO[bytes] | None) -> bytes:

--- a/src/libvcs/_internal/run.py
+++ b/src/libvcs/_internal/run.py
@@ -251,6 +251,8 @@ def run(
     # connected to a pseudo-TTY, which would require significant changes
     # to how subprocess execution is handled.
 
+    timeout_stdout: bytes | None = None
+    timeout_stderr: bytes | None = None
     if timeout is None:
         while code is None:
             code = proc.poll()
@@ -260,7 +262,7 @@ def run(
                 if line:
                     callback(output=line, timestamp=datetime.datetime.now())
     else:
-        code = _wait_with_deadline(
+        code, timeout_stdout, timeout_stderr = _wait_with_deadline(
             proc,
             deadline=time.monotonic() + timeout,
             callback=callback,
@@ -270,17 +272,27 @@ def run(
         callback(output="\r", timestamp=datetime.datetime.now())
 
     if proc.stdout is not None:
+        stdout_lines: list[bytes] = (
+            timeout_stdout.split(b"\n")
+            if timeout_stdout is not None
+            else proc.stdout.readlines()
+        )
         lines: t.Iterable[bytes] = filter(
             None,
-            (line.strip() for line in proc.stdout.readlines()),
+            (line.strip() for line in stdout_lines),
         )
         all_output = console_to_str(b"\n".join(lines))
     else:
         all_output = ""
     if code and proc.stderr is not None:
+        stderr_raw: list[bytes] = (
+            timeout_stderr.split(b"\n")
+            if timeout_stderr is not None
+            else proc.stderr.readlines()
+        )
         stderr_lines: t.Iterable[bytes] = filter(
             None,
-            (line.strip() for line in proc.stderr.readlines()),
+            (line.strip() for line in stderr_raw),
         )
         all_output = console_to_str(b"".join(stderr_lines))
     output = "".join(all_output)
@@ -306,39 +318,82 @@ def _wait_with_deadline(
     deadline: float,
     callback: ProgressCallbackProtocol | None,
     cmd: str | list[str],
-) -> int:
+) -> tuple[int, bytes | None, bytes | None]:
     """Wait for ``proc`` to exit, enforcing a wall-clock deadline.
 
-    Uses :mod:`selectors` so the wait unblocks when stderr is readable, when the
-    child exits, or when the per-iteration poll interval expires -- whichever
-    comes first. When the deadline is exceeded, the subprocess is reaped and
-    :class:`libvcs.exc.CommandTimeoutError` is raised with whatever output was
-    collected before the timeout.
+    Drains both ``stdout`` and ``stderr`` concurrently so a child that fills
+    either kernel pipe buffer (~64 KiB on Linux) cannot deadlock waiting for
+    libvcs to read its output. Uses :mod:`selectors` to unblock when either
+    stream is readable, when the child exits, or when the per-iteration poll
+    interval expires -- whichever comes first.
+
+    When the deadline is exceeded the subprocess is reaped and
+    :class:`libvcs.exc.CommandTimeoutError` is raised with the bytes captured
+    before the timeout. Otherwise the captured stdout/stderr are returned to
+    the caller alongside the exit code so they can be reused without re-
+    reading the now-drained pipes.
+
+    Returns
+    -------
+    tuple[int, bytes | None, bytes | None]
+        ``(returncode, stdout_bytes, stderr_bytes)``. A byte buffer is
+        ``None`` when the corresponding pipe could not be put into non-
+        blocking mode (Windows pipes, unusual fd types) -- in that case the
+        caller should fall back to reading the pipe directly.
     """
     sel = selectors.DefaultSelector()
-    stderr_stream = proc.stderr
-    if stderr_stream is not None:
-        # Non-blocking reads so the selector loop never stalls on a short read
-        # from a stuck child (e.g. git waiting on network or credentials).
-        try:
-            os.set_blocking(stderr_stream.fileno(), False)
-        except (OSError, ValueError):
-            stderr_stream = None
-        else:
-            sel.register(stderr_stream, selectors.EVENT_READ)
+    buffers: dict[t.IO[bytes], list[bytes]] = {}
+    registered: set[t.IO[bytes]] = set()
+    fds_to_restore: list[int] = []
 
-    partial_chunks: list[bytes] = []
+    for stream in (proc.stdout, proc.stderr):
+        if stream is None:
+            continue
+        # Non-blocking reads so the selector loop never stalls on a short read
+        # and a chatty child cannot fill a pipe buffer and wedge itself.
+        try:
+            fd = stream.fileno()
+            os.set_blocking(fd, False)
+        except (OSError, ValueError):
+            continue
+        sel.register(stream, selectors.EVENT_READ)
+        buffers[stream] = []
+        registered.add(stream)
+        fds_to_restore.append(fd)
+
+    code: int | None = None
     try:
         while True:
             code = proc.poll()
             if code is not None:
-                return code
+                # Final drain: data written between the last ``select()`` wake
+                # and the child's exit would otherwise be lost on the early
+                # return. Only drain streams we put into non-blocking mode.
+                for stream in list(registered):
+                    trailing = _drain_stream(stream)
+                    if trailing:
+                        buffers[stream].append(trailing)
+                        if (
+                            stream is proc.stderr
+                            and callback is not None
+                            and callable(callback)
+                        ):
+                            callback(
+                                output=console_to_str(trailing),
+                                timestamp=datetime.datetime.now(),
+                            )
+                break
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 _terminate_process(proc)
-                drained = _drain_stream(stderr_stream) + _drain_stream(proc.stdout)
-                message = console_to_str(b"".join(partial_chunks) + drained)
+                for stream in list(registered):
+                    trailing = _drain_stream(stream)
+                    if trailing:
+                        buffers[stream].append(trailing)
+                stdout_data = _join_buffer(buffers, proc.stdout)
+                stderr_data = _join_buffer(buffers, proc.stderr)
+                message = console_to_str((stdout_data or b"") + (stderr_data or b""))
                 raise exc.CommandTimeoutError(
                     output=message,
                     returncode=proc.returncode,
@@ -346,27 +401,58 @@ def _wait_with_deadline(
                 )
 
             wait = min(_TIMEOUT_POLL_INTERVAL_SECONDS, remaining)
-            events = sel.select(timeout=wait) if stderr_stream is not None else ()
+            if not registered:
+                # No streams to select on (e.g. ``os.set_blocking`` failed on
+                # Windows pipes). Yield the CPU explicitly instead of busy-
+                # looping until the deadline or process exit.
+                time.sleep(wait)
+                continue
+
+            events = sel.select(timeout=wait)
             if not events:
                 continue
 
             for key, _mask in events:
-                if key.fileobj is not stderr_stream:
-                    continue
+                stream = t.cast("t.IO[bytes]", key.fileobj)
                 try:
-                    chunk = stderr_stream.read(128)
+                    chunk = stream.read(128)
                 except (BlockingIOError, OSError):
                     chunk = b""
                 if not chunk:
+                    # EOF from the child closing the pipe. Stop selecting on
+                    # it so the loop doesn't spin on an always-readable fd.
+                    sel.unregister(stream)
+                    registered.discard(stream)
                     continue
-                partial_chunks.append(chunk)
-                if callback is not None and callable(callback):
+                buffers[stream].append(chunk)
+                if (
+                    stream is proc.stderr
+                    and callback is not None
+                    and callable(callback)
+                ):
                     callback(
                         output=console_to_str(chunk),
                         timestamp=datetime.datetime.now(),
                     )
     finally:
+        # Restore blocking mode so any subsequent read by the caller behaves
+        # as expected; ignore failures (fd already closed, Windows pipe).
+        for fd in fds_to_restore:
+            with contextlib.suppress(OSError, ValueError):
+                os.set_blocking(fd, True)
         sel.close()
+
+    return code, _join_buffer(buffers, proc.stdout), _join_buffer(buffers, proc.stderr)
+
+
+def _join_buffer(
+    buffers: dict[t.IO[bytes], list[bytes]],
+    stream: t.IO[bytes] | None,
+) -> bytes | None:
+    """Concatenate captured chunks for ``stream``, or ``None`` if not tracked."""
+    if stream is None or stream not in buffers:
+        return None
+    return b"".join(buffers[stream])
 
 
 def _terminate_process(proc: subprocess.Popen[bytes]) -> None:

--- a/src/libvcs/_internal/run.py
+++ b/src/libvcs/_internal/run.py
@@ -265,6 +265,7 @@ def run(
         code, timeout_stdout, timeout_stderr = _wait_with_deadline(
             proc,
             deadline=time.monotonic() + timeout,
+            timeout=timeout,
             callback=callback,
             cmd=_stringify_command(normalized_args),
         )
@@ -316,6 +317,7 @@ def _wait_with_deadline(
     proc: subprocess.Popen[bytes],
     *,
     deadline: float,
+    timeout: float,
     callback: ProgressCallbackProtocol | None,
     cmd: str | list[str],
 ) -> tuple[int, bytes | None, bytes | None]:
@@ -398,6 +400,7 @@ def _wait_with_deadline(
                     output=message,
                     returncode=proc.returncode,
                     cmd=cmd,
+                    timeout=timeout,
                 )
 
             wait = min(_TIMEOUT_POLL_INTERVAL_SECONDS, remaining)

--- a/src/libvcs/_internal/run.py
+++ b/src/libvcs/_internal/run.py
@@ -397,13 +397,13 @@ def _wait_with_deadline(
 
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                # ``vcs_exit_code`` deliberately omitted here: ``proc.returncode``
+                # is still ``None`` because the child has not been signalled yet,
+                # and CLAUDE.md treats ``vcs_exit_code`` as a scalar ``int``.
                 logger.warning(
                     "subprocess deadline exceeded after %.3gs",
                     timeout,
-                    extra={
-                        "vcs_cmd": _format_cmd_for_log(cmd),
-                        "vcs_exit_code": proc.returncode,
-                    },
+                    extra={"vcs_cmd": _format_cmd_for_log(cmd)},
                 )
                 _terminate_process(proc, cmd)
                 for stream in list(registered):

--- a/src/libvcs/_internal/run.py
+++ b/src/libvcs/_internal/run.py
@@ -10,11 +10,14 @@ This is an internal API not covered by versioning policy.
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import logging
 import os
+import selectors
 import subprocess
 import sys
+import time
 import typing as t
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 
@@ -147,6 +150,7 @@ def run(
     log_in_real_time: bool = False,
     check_returncode: bool = True,
     callback: ProgressCallbackProtocol | None = None,
+    timeout: float | None = None,
 ) -> str:
     """Run a command.
 
@@ -185,6 +189,13 @@ def run(
                 sys.stdout.write(output)
                 sys.stdout.flush()
             run(['git', 'pull'], callback=progress_cb)
+
+    timeout : float, optional
+        Seconds to wait before terminating the subprocess. When the deadline is
+        exceeded the process is sent ``SIGTERM`` (then ``SIGKILL`` after a short
+        grace period) and :class:`libvcs.exc.CommandTimeoutError` is raised with
+        any output collected so far. ``None`` (default) disables the deadline and
+        preserves the legacy behaviour of blocking until the process exits.
 
     Upcoming changes
     ----------------
@@ -240,13 +251,21 @@ def run(
     # connected to a pseudo-TTY, which would require significant changes
     # to how subprocess execution is handled.
 
-    while code is None:
-        code = proc.poll()
+    if timeout is None:
+        while code is None:
+            code = proc.poll()
 
-        if callback and callable(callback) and proc.stderr is not None:
-            line = console_to_str(proc.stderr.read(128))
-            if line:
-                callback(output=line, timestamp=datetime.datetime.now())
+            if callback and callable(callback) and proc.stderr is not None:
+                line = console_to_str(proc.stderr.read(128))
+                if line:
+                    callback(output=line, timestamp=datetime.datetime.now())
+    else:
+        code = _wait_with_deadline(
+            proc,
+            deadline=time.monotonic() + timeout,
+            callback=callback,
+            cmd=_stringify_command(normalized_args),
+        )
     if callback and callable(callback):
         callback(output="\r", timestamp=datetime.datetime.now())
 
@@ -272,3 +291,109 @@ def run(
             cmd=_stringify_command(normalized_args),
         )
     return output
+
+
+#: Grace period after ``terminate()`` before escalating to ``kill()``.
+_TIMEOUT_KILL_GRACE_SECONDS = 0.5
+
+#: Upper bound on the ``selectors.select()`` wait inside the deadline loop.
+_TIMEOUT_POLL_INTERVAL_SECONDS = 0.1
+
+
+def _wait_with_deadline(
+    proc: subprocess.Popen[bytes],
+    *,
+    deadline: float,
+    callback: ProgressCallbackProtocol | None,
+    cmd: str | list[str],
+) -> int:
+    """Wait for ``proc`` to exit, enforcing a wall-clock deadline.
+
+    Uses :mod:`selectors` so the wait unblocks when stderr is readable, when the
+    child exits, or when the per-iteration poll interval expires -- whichever
+    comes first. When the deadline is exceeded, the subprocess is reaped and
+    :class:`libvcs.exc.CommandTimeoutError` is raised with whatever output was
+    collected before the timeout.
+    """
+    sel = selectors.DefaultSelector()
+    stderr_stream = proc.stderr
+    if stderr_stream is not None:
+        # Non-blocking reads so the selector loop never stalls on a short read
+        # from a stuck child (e.g. git waiting on network or credentials).
+        try:
+            os.set_blocking(stderr_stream.fileno(), False)
+        except (OSError, ValueError):
+            stderr_stream = None
+        else:
+            sel.register(stderr_stream, selectors.EVENT_READ)
+
+    partial_chunks: list[bytes] = []
+    try:
+        while True:
+            code = proc.poll()
+            if code is not None:
+                return code
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                _terminate_process(proc)
+                drained = _drain_stream(stderr_stream) + _drain_stream(proc.stdout)
+                message = console_to_str(b"".join(partial_chunks) + drained)
+                raise exc.CommandTimeoutError(
+                    output=message,
+                    returncode=proc.returncode,
+                    cmd=cmd,
+                )
+
+            wait = min(_TIMEOUT_POLL_INTERVAL_SECONDS, remaining)
+            events = sel.select(timeout=wait) if stderr_stream is not None else ()
+            if not events:
+                continue
+
+            for key, _mask in events:
+                if key.fileobj is not stderr_stream:
+                    continue
+                try:
+                    chunk = stderr_stream.read(128)
+                except (BlockingIOError, OSError):
+                    chunk = b""
+                if not chunk:
+                    continue
+                partial_chunks.append(chunk)
+                if callback is not None and callable(callback):
+                    callback(
+                        output=console_to_str(chunk),
+                        timestamp=datetime.datetime.now(),
+                    )
+    finally:
+        sel.close()
+
+
+def _terminate_process(proc: subprocess.Popen[bytes]) -> None:
+    """Terminate ``proc`` gracefully, falling back to ``kill`` on the grace."""
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+    except (OSError, ProcessLookupError):
+        return
+    try:
+        proc.wait(timeout=_TIMEOUT_KILL_GRACE_SECONDS)
+    except subprocess.TimeoutExpired:
+        with contextlib.suppress(OSError, ProcessLookupError):
+            proc.kill()
+        # If the child is still unreachable after SIGKILL, bail rather than
+        # block forever -- we've already signalled the user-facing timeout.
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=_TIMEOUT_KILL_GRACE_SECONDS)
+
+
+def _drain_stream(stream: t.IO[bytes] | None) -> bytes:
+    """Best-effort read of any remaining bytes from a subprocess pipe."""
+    if stream is None:
+        return b""
+    try:
+        data = stream.read() or b""
+    except (BlockingIOError, OSError, ValueError):
+        data = b""
+    return data

--- a/src/libvcs/_internal/run.py
+++ b/src/libvcs/_internal/run.py
@@ -342,6 +342,15 @@ def _wait_with_deadline(
         ``None`` when the corresponding pipe could not be put into non-
         blocking mode (Windows pipes, unusual fd types) -- in that case the
         caller should fall back to reading the pipe directly.
+
+    Notes
+    -----
+    The progress ``callback`` is invoked for ``stderr`` chunks only,
+    matching the legacy non-timeout codepath. ``stdout`` is drained into
+    the returned buffer to prevent the child from blocking on a full pipe,
+    but its chunks are not forwarded to the callback in real time. Callers
+    that want streaming ``stdout`` should redirect it themselves
+    (e.g. ``stdout=`` to a file) rather than relying on ``callback``.
     """
     sel = selectors.DefaultSelector()
     buffers: dict[t.IO[bytes], list[bytes]] = {}

--- a/src/libvcs/cmd/git.py
+++ b/src/libvcs/cmd/git.py
@@ -146,6 +146,7 @@ class Git:
         config_env: str | None = None,
         # Pass-through to run()
         log_in_real_time: bool = False,
+        timeout: float | None = None,
         **kwargs: t.Any,
     ) -> str:
         """Run a command for this git repository.
@@ -205,6 +206,13 @@ class Git:
             ``--config=<name>=<value>``
         config_env :
             ``--config-env=<name>=<envvar>``
+        timeout : float, optional
+            Wall-clock seconds to wait before terminating the subprocess.
+            ``None`` (default) preserves the legacy behaviour of blocking
+            until the process exits. When the deadline is exceeded the
+            process is sent ``SIGTERM`` (then ``SIGKILL`` after a grace
+            period) and :class:`libvcs.exc.CommandTimeoutError` is raised
+            with any output collected so far.
 
         Examples
         --------
@@ -281,7 +289,7 @@ class Git:
         if self.progress_callback is not None:
             kwargs["callback"] = self.progress_callback
 
-        return run(args=cli_args, **kwargs)
+        return run(args=cli_args, timeout=timeout, **kwargs)
 
     def clone(
         self,

--- a/src/libvcs/cmd/hg.py
+++ b/src/libvcs/cmd/hg.py
@@ -98,6 +98,7 @@ class Hg:
         pager: HgPagerType | None = None,
         color: HgColorType | None = None,
         check_returncode: bool | None = None,
+        timeout: float | None = None,
         **kwargs: t.Any,
     ) -> str:
         """Run a command for this Mercurial repository.
@@ -149,6 +150,13 @@ class Hg:
             ``--config CONFIG [+]``, ``section.name=value``
         check_returncode : bool, default: ``True``
             Passthrough to :func:`libvcs._internal.run.run()`
+        timeout : float, optional
+            Wall-clock seconds to wait before terminating the subprocess.
+            ``None`` (default) preserves the legacy behaviour of blocking
+            until the process exits. When the deadline is exceeded the
+            process is sent ``SIGTERM`` (then ``SIGKILL`` after a grace
+            period) and :class:`libvcs.exc.CommandTimeoutError` is raised
+            with any output collected so far.
 
         Examples
         --------
@@ -194,6 +202,7 @@ class Hg:
         return run(
             args=cli_args,
             check_returncode=True if check_returncode is None else check_returncode,
+            timeout=timeout,
             **kwargs,
         )
 

--- a/src/libvcs/cmd/svn.py
+++ b/src/libvcs/cmd/svn.py
@@ -83,6 +83,7 @@ class Svn:
         # Special behavior
         make_parents: bool | None = True,
         check_returncode: bool | None = None,
+        timeout: float | None = None,
         **kwargs: t.Any,
     ) -> str:
         """Run a command for this SVN working copy.
@@ -119,6 +120,13 @@ class Svn:
             Creates checkout directory (`:attr:`self.path`) if it doesn't already exist.
         check_returncode : bool, default: ``None``
             Passthrough to :meth:`Svn.run`
+        timeout : float, optional
+            Wall-clock seconds to wait before terminating the subprocess.
+            ``None`` (default) preserves the legacy behaviour of blocking
+            until the process exits. When the deadline is exceeded the
+            process is sent ``SIGTERM`` (then ``SIGKILL`` after a grace
+            period) and :class:`libvcs.exc.CommandTimeoutError` is raised
+            with any output collected so far.
 
         Examples
         --------
@@ -152,6 +160,7 @@ class Svn:
         return run(
             args=cli_args,
             check_returncode=True if check_returncode is None else check_returncode,
+            timeout=timeout,
             **kwargs,
         )
 

--- a/src/libvcs/exc.py
+++ b/src/libvcs/exc.py
@@ -34,7 +34,47 @@ class CommandError(LibVCSException):
 
 
 class CommandTimeoutError(CommandError):
-    """CommandError which gets raised when a subprocess exceeds its timeout."""
+    r"""CommandError raised when a subprocess exceeds its wall-clock timeout.
+
+    Carries the deadline used when the timeout fired so callers and human
+    readers see the duration in the rendered message rather than the
+    misleading ``"Command failed with code None: ..."`` produced by the
+    bare :class:`CommandError` template (the child is not necessarily reaped
+    before the exception is raised, leaving ``returncode`` ``None``).
+
+    Examples
+    --------
+    >>> err = CommandTimeoutError(
+    ...     output='partial output',
+    ...     cmd='git fetch',
+    ...     timeout=2.5,
+    ... )
+    >>> print(str(err))
+    Command timed out after 2.5s: git fetch
+    partial output
+    """
+
+    def __init__(
+        self,
+        output: str,
+        returncode: int | None = None,
+        cmd: str | list[str] | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        super().__init__(output=output, returncode=returncode, cmd=cmd)
+        #: Wall-clock deadline (seconds) the subprocess exceeded, if known.
+        self.timeout = timeout
+
+    def __str__(self) -> str:
+        """Render the timeout duration alongside the command and partial output."""
+        cmd = getattr(self, "cmd", "")
+        if self.timeout is not None:
+            message = f"Command timed out after {self.timeout:g}s: {cmd}"
+        else:
+            message = f"Command timed out: {cmd}"
+        if self.output.strip():
+            message += f"\n{self.output}"
+        return message
 
 
 class InvalidVCS(LibVCSException):

--- a/src/libvcs/sync/git.py
+++ b/src/libvcs/sync/git.py
@@ -676,15 +676,24 @@ class GitSync(BaseSync):
 
         Notes
         -----
-        Uses ``git remote -v`` (via the cached remote manager) instead of
+        Uses ``git remote -v`` via the remote manager rather than
         ``git remote show -n``. ``git remote show`` also enumerates every
         remote-tracking ref, which pipes thousands of lines through the
         subprocess progress callback for repositories with large branch
         counts (e.g. ``openai/codex`` at 2,400+ refs) and can appear to
         hang. ``git remote -v`` is O(remotes) and cannot block on ref
         enumeration.
+
+        Subprocess failures from the underlying ``git remote -v`` are
+        suppressed and returned as ``None`` to preserve the resilience
+        contract callers relied on with the previous ``git remote show``
+        path (which wrapped the same call in ``try / except
+        LibVCSException``).
         """
-        remote_cmd = self.cmd.remotes.get(remote_name=name, default=None)
+        try:
+            remote_cmd = self.cmd.remotes.get(remote_name=name, default=None)
+        except exc.LibVCSException:
+            return None
         if remote_cmd is None:
             return None
 

--- a/src/libvcs/sync/git.py
+++ b/src/libvcs/sync/git.py
@@ -682,7 +682,9 @@ class GitSync(BaseSync):
         subprocess progress callback for repositories with large branch
         counts (e.g. ``openai/codex`` at 2,400+ refs) and can appear to
         hang. ``git remote -v`` is O(remotes) and cannot block on ref
-        enumeration.
+        enumeration. The remote manager is uncached -- each call shells
+        out -- so repeated calls in a loop will still spawn one
+        subprocess apiece.
 
         Subprocess failures from the underlying ``git remote -v`` are
         suppressed and returned as ``None`` to preserve the resilience

--- a/src/libvcs/sync/git.py
+++ b/src/libvcs/sync/git.py
@@ -673,25 +673,34 @@ class GitSync(BaseSync):
         Returns
         -------
         Remote name and url in tuple form
+
+        Notes
+        -----
+        Uses ``git remote -v`` (via the cached remote manager) instead of
+        ``git remote show -n``. ``git remote show`` also enumerates every
+        remote-tracking ref, which pipes thousands of lines through the
+        subprocess progress callback for repositories with large branch
+        counts (e.g. ``openai/codex`` at 2,400+ refs) and can appear to
+        hang. ``git remote -v`` is O(remotes) and cannot block on ref
+        enumeration.
         """
-        try:
-            ret = self.cmd.remotes.show(
-                name=name,
-                no_query_remotes=True,
-                log_in_real_time=True,
-            )
-            lines = ret.split("\n")
-            remote_fetch_url = lines[1].replace("Fetch URL: ", "").strip()
-            remote_push_url = lines[2].replace("Push  URL: ", "").strip()
-            if name not in {remote_fetch_url, remote_push_url}:
-                return GitRemote(
-                    name=name,
-                    fetch_url=remote_fetch_url,
-                    push_url=remote_push_url,
-                )
-        except exc.LibVCSException:
-            pass
-        return None
+        remote_cmd = self.cmd.remotes.get(remote_name=name, default=None)
+        if remote_cmd is None:
+            return None
+
+        fetch_url = (remote_cmd.fetch_url or "").strip()
+        if not fetch_url:
+            return None
+
+        # When no explicit ``remote.<name>.pushurl`` is set, git itself falls
+        # back to the fetch URL -- mirror that so callers always see a URL.
+        push_url = (remote_cmd.push_url or fetch_url).strip()
+
+        return GitRemote(
+            name=name,
+            fetch_url=fetch_url,
+            push_url=push_url,
+        )
 
     def set_remote(
         self,

--- a/tests/_internal/test_run.py
+++ b/tests/_internal/test_run.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 import pathlib
+import subprocess
+import sys
+import time
+import typing as t
 
-from libvcs._internal.run import _normalize_command_args
+import pytest
+
+from libvcs import exc
+from libvcs._internal.run import _normalize_command_args, run
 
 
 def test_normalize_command_args_keeps_scalar_string() -> None:
@@ -28,3 +35,91 @@ def test_normalize_command_args_coerces_pathlike() -> None:
 
     assert _normalize_command_args(path) == ["example"]
     assert _normalize_command_args([path, "status"]) == ["example", "status"]
+
+
+def test_run_without_timeout_matches_legacy_behavior() -> None:
+    """Leaving ``timeout=None`` preserves the pre-timeout call semantics."""
+    output = run([sys.executable, "-c", "print('hello'); print('world')"])
+
+    assert "hello" in output
+    assert "world" in output
+
+
+def test_run_raises_command_timeout_when_deadline_exceeded() -> None:
+    """A command sleeping past ``timeout`` raises ``CommandTimeoutError`` fast."""
+    started = time.monotonic()
+
+    with pytest.raises(exc.CommandTimeoutError) as excinfo:
+        run(
+            [sys.executable, "-c", "import time; time.sleep(10)"],
+            timeout=0.3,
+        )
+
+    elapsed = time.monotonic() - started
+
+    # Upper bound keeps the test honest: the deadline must actually fire, not
+    # fall through to the legacy unbounded wait.
+    assert elapsed < 2.5, f"timeout took too long: {elapsed:.2f}s"
+    assert isinstance(excinfo.value, exc.CommandError)
+
+
+def test_run_timeout_captures_partial_stderr_output() -> None:
+    """Output produced before the timeout is preserved on ``CommandTimeoutError``."""
+    script = (
+        "import sys, time;"
+        "sys.stderr.write('first\\n');"
+        "sys.stderr.flush();"
+        "time.sleep(10)"
+    )
+
+    with pytest.raises(exc.CommandTimeoutError) as excinfo:
+        run(
+            [sys.executable, "-c", script],
+            timeout=0.5,
+            log_in_real_time=True,
+        )
+
+    # The pre-timeout stderr chunk is forwarded to the callback and stashed in
+    # the exception's ``output`` so callers can diagnose what the process was
+    # doing before it was killed.
+    assert "first" in excinfo.value.output
+
+
+def test_run_timeout_reaps_child_process() -> None:
+    """Timed-out processes are terminated; no zombies remain in the group."""
+    script = "import time; time.sleep(10)"
+
+    captured: dict[str, t.Any] = {}
+    original_popen = subprocess.Popen
+
+    def _capturing_popen(*args: t.Any, **kwargs: t.Any) -> t.Any:
+        proc = original_popen(*args, **kwargs)
+        captured["proc"] = proc
+        return proc
+
+    # Attribute replacement keeps the test narrow -- we just need a handle on
+    # the Popen that ``run`` created so we can assert the child was actually
+    # reaped rather than abandoned (no zombie left behind).
+    subprocess.Popen = _capturing_popen  # type: ignore[misc,assignment]
+    try:
+        with pytest.raises(exc.CommandTimeoutError):
+            run([sys.executable, "-c", script], timeout=0.3)
+    finally:
+        subprocess.Popen = original_popen  # type: ignore[misc]
+
+    proc = captured["proc"]
+    # ``returncode`` is only populated once ``wait`` succeeds, so a populated
+    # value proves the timeout branch both killed and reaped the child.
+    assert proc.returncode is not None
+
+
+def test_run_without_timeout_completes_successfully() -> None:
+    """Regression guard: quick commands return output, no TimeoutError, no hang."""
+    output = run([sys.executable, "-c", "print('ok')"])
+    assert "ok" in output
+
+
+def test_run_timeout_none_is_the_default() -> None:
+    """Omitting ``timeout`` is equivalent to ``timeout=None``."""
+    output = run([sys.executable, "-c", "print('default')"], timeout=None)
+    assert "default" in output

--- a/tests/_internal/test_run.py
+++ b/tests/_internal/test_run.py
@@ -123,3 +123,68 @@ def test_run_timeout_none_is_the_default() -> None:
     """Omitting ``timeout`` is equivalent to ``timeout=None``."""
     output = run([sys.executable, "-c", "print('default')"], timeout=None)
     assert "default" in output
+
+
+def test_run_timeout_does_not_deadlock_on_chatty_stdout() -> None:
+    """A child filling its stdout pipe must not deadlock the deadline loop.
+
+    The OS pipe buffer is typically 64 KiB on Linux. The child below writes
+    well past that before exiting; if the parent only drained ``stderr``, the
+    child would block on ``write()`` and only ``terminate()`` would unwedge
+    it, losing all the legitimate output.
+    """
+    script = "import sys; sys.stdout.write('x' * 200000); sys.stdout.flush()"
+
+    output = run([sys.executable, "-c", script], timeout=15.0)
+
+    assert len(output) >= 200000
+
+
+def test_run_timeout_preserves_stdout_after_exit() -> None:
+    """Captured stdout from the deadline loop survives back to the caller."""
+    script = "print('preserved'); print('lines')"
+    output = run([sys.executable, "-c", script], timeout=10.0)
+
+    assert "preserved" in output
+    assert "lines" in output
+
+
+def test_run_timeout_captures_partial_stdout_on_timeout() -> None:
+    """Stdout flushed before the deadline appears in ``CommandTimeoutError.output``."""
+    script = (
+        "import sys, time; "
+        "sys.stdout.write('partial-stdout\\n'); "
+        "sys.stdout.flush(); "
+        "time.sleep(10)"
+    )
+
+    with pytest.raises(exc.CommandTimeoutError) as excinfo:
+        run([sys.executable, "-c", script], timeout=0.5)
+
+    assert "partial-stdout" in excinfo.value.output
+
+
+def test_run_timeout_handles_early_stderr_close_without_hanging() -> None:
+    """A child that closes stderr long before exiting must not stall the loop.
+
+    Before the EOF-unregister fix, ``selectors.select`` kept waking on the
+    closed-but-readable stderr fd, the read returned ``b""``, and the loop
+    spun until the deadline. With the unregister, the stream is removed
+    after the first empty read and the loop returns to waiting on the
+    remaining fd or the poll interval.
+    """
+    script = (
+        "import os, sys, time; "
+        "os.close(sys.stderr.fileno()); "
+        "time.sleep(0.2); "
+        "print('done')"
+    )
+    started = time.monotonic()
+
+    output = run([sys.executable, "-c", script], timeout=10.0)
+
+    elapsed = time.monotonic() - started
+    assert "done" in output
+    # An upper bound that's loose enough not to flake but tight enough to
+    # catch a regression where the EOF unregister is undone.
+    assert elapsed < 5.0, f"early-stderr-close path took too long: {elapsed:.2f}s"

--- a/tests/_internal/test_run.py
+++ b/tests/_internal/test_run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import pathlib
 import subprocess
 import sys
@@ -198,6 +199,29 @@ def test_run_timeout_captures_partial_stdout_on_timeout() -> None:
         run([sys.executable, "-c", script], timeout=0.5)
 
     assert "partial-stdout" in excinfo.value.output
+
+
+def test_run_timeout_logs_deadline_exceeded(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Deadline-fired path emits a WARNING with the canonical ``vcs_cmd`` extra."""
+    with (
+        caplog.at_level(logging.WARNING, logger="libvcs._internal.run"),
+        pytest.raises(exc.CommandTimeoutError),
+    ):
+        run([sys.executable, "-c", "import time; time.sleep(10)"], timeout=0.3)
+
+    deadline_records = [
+        record
+        for record in caplog.records
+        if "deadline exceeded" in record.getMessage()
+    ]
+    assert len(deadline_records) == 1
+    record = deadline_records[0]
+    assert record.levelname == "WARNING"
+    assert hasattr(record, "vcs_cmd")
+    cmd_extra = t.cast("str", record.vcs_cmd)
+    assert "time.sleep" in cmd_extra
 
 
 def test_run_timeout_handles_early_stderr_close_without_hanging() -> None:

--- a/tests/_internal/test_run.py
+++ b/tests/_internal/test_run.py
@@ -17,22 +17,6 @@ from libvcs._internal import run as run_module
 from libvcs._internal.run import _normalize_command_args, run
 
 
-@pytest.fixture
-def fast_timeout_constants(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Tighten the deadline-loop spread so test wall-clock budgets stay reliable.
-
-    The two ``_TIMEOUT_*`` constants in :mod:`libvcs._internal.run` are tuned
-    for production use (0.5 s SIGTERM grace, 0.1 s selector poll). For tests
-    that intentionally fire the deadline, those defaults add up to ~0.7 s of
-    unavoidable wall-clock spread on top of the test's nominal timeout, which
-    makes upper-bound assertions fragile on loaded CI runners. This fixture
-    monkeypatches both to 0.05 s so the spread stays predictable; production
-    behaviour is unchanged.
-    """
-    monkeypatch.setattr(run_module, "_TIMEOUT_KILL_GRACE_SECONDS", 0.05)
-    monkeypatch.setattr(run_module, "_TIMEOUT_POLL_INTERVAL_SECONDS", 0.05)
-
-
 def test_normalize_command_args_keeps_scalar_string() -> None:
     """Scalar strings should remain a single subprocess argument."""
     assert _normalize_command_args("status") == ["status"]

--- a/tests/_internal/test_run.py
+++ b/tests/_internal/test_run.py
@@ -12,7 +12,24 @@ import typing as t
 import pytest
 
 from libvcs import exc
+from libvcs._internal import run as run_module
 from libvcs._internal.run import _normalize_command_args, run
+
+
+@pytest.fixture
+def fast_timeout_constants(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tighten the deadline-loop spread so test wall-clock budgets stay reliable.
+
+    The two ``_TIMEOUT_*`` constants in :mod:`libvcs._internal.run` are tuned
+    for production use (0.5 s SIGTERM grace, 0.1 s selector poll). For tests
+    that intentionally fire the deadline, those defaults add up to ~0.7 s of
+    unavoidable wall-clock spread on top of the test's nominal timeout, which
+    makes upper-bound assertions fragile on loaded CI runners. This fixture
+    monkeypatches both to 0.05 s so the spread stays predictable; production
+    behaviour is unchanged.
+    """
+    monkeypatch.setattr(run_module, "_TIMEOUT_KILL_GRACE_SECONDS", 0.05)
+    monkeypatch.setattr(run_module, "_TIMEOUT_POLL_INTERVAL_SECONDS", 0.05)
 
 
 def test_normalize_command_args_keeps_scalar_string() -> None:
@@ -46,7 +63,9 @@ def test_run_without_timeout_matches_legacy_behavior() -> None:
     assert "world" in output
 
 
-def test_run_raises_command_timeout_when_deadline_exceeded() -> None:
+def test_run_raises_command_timeout_when_deadline_exceeded(
+    fast_timeout_constants: None,
+) -> None:
     """A command sleeping past ``timeout`` raises ``CommandTimeoutError`` fast."""
     started = time.monotonic()
 
@@ -59,12 +78,17 @@ def test_run_raises_command_timeout_when_deadline_exceeded() -> None:
     elapsed = time.monotonic() - started
 
     # Upper bound keeps the test honest: the deadline must actually fire, not
-    # fall through to the legacy unbounded wait.
-    assert elapsed < 2.5, f"timeout took too long: {elapsed:.2f}s"
+    # fall through to the legacy unbounded wait. With the fast-constants
+    # fixture, the worst-case spread is 0.3 (deadline) + 0.05 (SIGTERM grace)
+    # + 0.05 (poll) + Python startup (~0.5 s on cold CI) -> ~1 s; the budget
+    # below leaves comfortable headroom for slow runners.
+    assert elapsed < 2.0, f"timeout took too long: {elapsed:.2f}s"
     assert isinstance(excinfo.value, exc.CommandError)
 
 
-def test_run_timeout_captures_partial_stderr_output() -> None:
+def test_run_timeout_captures_partial_stderr_output(
+    fast_timeout_constants: None,
+) -> None:
     """Output produced before the timeout is preserved on ``CommandTimeoutError``."""
     script = (
         "import sys, time;"
@@ -86,7 +110,10 @@ def test_run_timeout_captures_partial_stderr_output() -> None:
     assert "first" in excinfo.value.output
 
 
-def test_run_timeout_reaps_child_process(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_timeout_reaps_child_process(
+    monkeypatch: pytest.MonkeyPatch,
+    fast_timeout_constants: None,
+) -> None:
     """Timed-out processes are terminated; no zombies remain in the group."""
     script = "import time; time.sleep(10)"
 
@@ -151,7 +178,9 @@ def test_command_timeout_error_without_timeout_falls_back() -> None:
     assert "partial" in rendered
 
 
-def test_run_timeout_message_includes_duration() -> None:
+def test_run_timeout_message_includes_duration(
+    fast_timeout_constants: None,
+) -> None:
     """``run(..., timeout=X)`` raises an exception whose ``str()`` shows X."""
     with pytest.raises(exc.CommandTimeoutError) as excinfo:
         run([sys.executable, "-c", "import time; time.sleep(10)"], timeout=0.3)
@@ -186,7 +215,9 @@ def test_run_timeout_preserves_stdout_after_exit() -> None:
     assert "lines" in output
 
 
-def test_run_timeout_captures_partial_stdout_on_timeout() -> None:
+def test_run_timeout_captures_partial_stdout_on_timeout(
+    fast_timeout_constants: None,
+) -> None:
     """Stdout flushed before the deadline appears in ``CommandTimeoutError.output``."""
     script = (
         "import sys, time; "
@@ -203,6 +234,7 @@ def test_run_timeout_captures_partial_stdout_on_timeout() -> None:
 
 def test_run_timeout_logs_deadline_exceeded(
     caplog: pytest.LogCaptureFixture,
+    fast_timeout_constants: None,
 ) -> None:
     """Deadline-fired path emits a WARNING with the canonical ``vcs_cmd`` extra."""
     with (
@@ -224,6 +256,10 @@ def test_run_timeout_logs_deadline_exceeded(
     assert "time.sleep" in cmd_extra
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.close(sys.stderr.fileno()) has POSIX-specific semantics",
+)
 def test_run_timeout_handles_early_stderr_close_without_hanging() -> None:
     """A child that closes stderr long before exiting must not stall the loop.
 

--- a/tests/_internal/test_run.py
+++ b/tests/_internal/test_run.py
@@ -125,6 +125,44 @@ def test_run_timeout_none_is_the_default() -> None:
     assert "default" in output
 
 
+def test_command_timeout_error_renders_duration() -> None:
+    """Direct ``CommandTimeoutError`` construction surfaces the duration."""
+    err = exc.CommandTimeoutError(
+        output="",
+        returncode=None,
+        cmd="git fetch origin",
+        timeout=2.5,
+    )
+
+    rendered = str(err)
+    assert "timed out after 2.5s" in rendered
+    assert "git fetch origin" in rendered
+    # Regression guard: the bare ``CommandError`` template would have produced
+    # ``"Command failed with code None: ..."`` when ``returncode`` is ``None``.
+    assert "code None" not in rendered
+
+
+def test_command_timeout_error_without_timeout_falls_back() -> None:
+    """Omitting ``timeout=`` still produces a readable timeout message."""
+    err = exc.CommandTimeoutError(output="partial", cmd="git fetch")
+
+    rendered = str(err)
+    assert "timed out" in rendered
+    assert "git fetch" in rendered
+    assert "partial" in rendered
+
+
+def test_run_timeout_message_includes_duration() -> None:
+    """``run(..., timeout=X)`` raises an exception whose ``str()`` shows X."""
+    with pytest.raises(exc.CommandTimeoutError) as excinfo:
+        run([sys.executable, "-c", "import time; time.sleep(10)"], timeout=0.3)
+
+    assert excinfo.value.timeout == 0.3
+    rendered = str(excinfo.value)
+    assert "timed out after" in rendered
+    assert "0.3" in rendered
+
+
 def test_run_timeout_does_not_deadlock_on_chatty_stdout() -> None:
     """A child filling its stdout pipe must not deadlock the deadline loop.
 

--- a/tests/_internal/test_run.py
+++ b/tests/_internal/test_run.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import time
 import typing as t
+import unittest.mock
 
 import pytest
 
@@ -254,6 +255,50 @@ def test_run_timeout_logs_deadline_exceeded(
     assert hasattr(record, "vcs_cmd")
     cmd_extra = t.cast("str", record.vcs_cmd)
     assert "time.sleep" in cmd_extra
+
+
+def test_terminate_process_warns_when_sigkill_does_not_reap(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A child that resists ``SIGKILL`` surfaces a WARNING with ``vcs_cmd``.
+
+    Reproducing a true uninterruptible (``D`` state on POSIX) child requires
+    kernel fixtures that aren't available in a pytest run, so we substitute
+    a ``MagicMock`` whose ``poll()`` always reports the child alive and
+    whose ``wait()`` always raises ``TimeoutExpired``. That drives both
+    branches inside ``_terminate_process`` -- SIGTERM grace expires
+    (DEBUG escalation log), SIGKILL is sent, the second wait also times
+    out, and the final ``poll() is None`` triggers the WARNING this test
+    asserts on.
+    """
+    fake_proc = unittest.mock.MagicMock(spec=subprocess.Popen)
+    fake_proc.args = ["sleep", "60"]
+    fake_proc.returncode = None
+    fake_proc.poll.return_value = None
+    fake_proc.wait.side_effect = subprocess.TimeoutExpired(
+        cmd=fake_proc.args,
+        timeout=0.05,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="libvcs._internal.run"):
+        run_module._terminate_process(
+            t.cast("subprocess.Popen[bytes]", fake_proc),
+            "test-cmd",
+        )
+
+    fake_proc.terminate.assert_called_once()
+    fake_proc.kill.assert_called_once()
+
+    warnings = [
+        record
+        for record in caplog.records
+        if record.levelname == "WARNING" and "did not reap" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+    record = warnings[0]
+    assert hasattr(record, "vcs_cmd")
+    cmd_extra = t.cast("str", record.vcs_cmd)
+    assert cmd_extra == "test-cmd"
 
 
 @pytest.mark.skipif(

--- a/tests/_internal/test_run.py
+++ b/tests/_internal/test_run.py
@@ -85,7 +85,7 @@ def test_run_timeout_captures_partial_stderr_output() -> None:
     assert "first" in excinfo.value.output
 
 
-def test_run_timeout_reaps_child_process() -> None:
+def test_run_timeout_reaps_child_process(monkeypatch: pytest.MonkeyPatch) -> None:
     """Timed-out processes are terminated; no zombies remain in the group."""
     script = "import time; time.sleep(10)"
 
@@ -97,15 +97,13 @@ def test_run_timeout_reaps_child_process() -> None:
         captured["proc"] = proc
         return proc
 
-    # Attribute replacement keeps the test narrow -- we just need a handle on
-    # the Popen that ``run`` created so we can assert the child was actually
-    # reaped rather than abandoned (no zombie left behind).
-    subprocess.Popen = _capturing_popen  # type: ignore[misc,assignment]
-    try:
-        with pytest.raises(exc.CommandTimeoutError):
-            run([sys.executable, "-c", script], timeout=0.3)
-    finally:
-        subprocess.Popen = original_popen  # type: ignore[misc]
+    # ``monkeypatch.setattr`` auto-restores even if the test body raises and
+    # is safe under ``pytest-xdist`` parallel runs, unlike a hand-rolled
+    # try/finally around a global assignment.
+    monkeypatch.setattr(subprocess, "Popen", _capturing_popen)
+
+    with pytest.raises(exc.CommandTimeoutError):
+        run([sys.executable, "-c", script], timeout=0.3)
 
     proc = captured["proc"]
     # ``returncode`` is only populated once ``wait`` succeeds, so a populated

--- a/tests/cmd/test_git.py
+++ b/tests/cmd/test_git.py
@@ -12,6 +12,8 @@ from libvcs._internal.query_list import ObjectDoesNotExist
 from libvcs.cmd import git
 
 if t.TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
     from libvcs.pytest_plugin import CreateRepoFn, GitCommitEnvVars
     from libvcs.sync.git import GitSync
 
@@ -42,6 +44,24 @@ def test_git_run_accepts_scalar_string(tmp_path: pathlib.Path) -> None:
     result = repo.run("--version")
 
     assert result.startswith("git version ")
+
+
+def test_git_run_timeout_propagates_to_runner(
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """``Git.run(timeout=X)`` forwards X to the underlying ``run()`` call.
+
+    Regression guard for the discoverability fix: ``timeout=`` is part of the
+    public ``Git.run`` signature rather than reachable only via ``**kwargs``.
+    """
+    repo = git.Git(path=tmp_path)
+    mock_run = mocker.patch("libvcs.cmd.git.run", return_value="")
+
+    repo.run(["--version"], timeout=2.5)
+
+    _args, kwargs = mock_run.call_args
+    assert kwargs.get("timeout") == 2.5
 
 
 def test_git_init_bare(tmp_path: pathlib.Path) -> None:

--- a/tests/cmd/test_git.py
+++ b/tests/cmd/test_git.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import os
 import pathlib
+import subprocess
+import time
 import typing as t
 
 import pytest
 
+from libvcs import exc
 from libvcs._internal.query_list import ObjectDoesNotExist
 from libvcs.cmd import git
 
@@ -62,6 +65,34 @@ def test_git_run_timeout_propagates_to_runner(
 
     _args, kwargs = mock_run.call_args
     assert kwargs.get("timeout") == 2.5
+
+
+def test_git_run_timeout_e2e_raises_command_timeout(
+    git_repo: GitSync,
+    fast_timeout_constants: None,
+) -> None:
+    """End-to-end: ``Git.run(timeout=...)`` against a real subprocess that hangs.
+
+    ``git cat-file --batch`` reads object names from stdin one per line. With
+    ``stdin=subprocess.PIPE`` and no input written (nor EOF signalled), the
+    child blocks on the read forever -- so the deadline must fire and
+    ``Git.run`` must raise :class:`libvcs.exc.CommandTimeoutError`. Exercises
+    the full public path (``Git.run`` -> ``run`` -> ``_wait_with_deadline``)
+    without mocks.
+    """
+    started = time.monotonic()
+
+    with pytest.raises(exc.CommandTimeoutError):
+        git_repo.cmd.run(
+            ["cat-file", "--batch"],
+            stdin=subprocess.PIPE,
+            timeout=0.3,
+        )
+
+    elapsed = time.monotonic() - started
+    # Worst-case wall clock with the fast-constants fixture: 0.3 (deadline)
+    # + 0.05 (SIGTERM grace) + 0.05 (poll) + git startup overhead.
+    assert elapsed < 2.0, f"Git.run timeout took too long: {elapsed:.2f}s"
 
 
 def test_git_init_bare(tmp_path: pathlib.Path) -> None:

--- a/tests/cmd/test_hg.py
+++ b/tests/cmd/test_hg.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import pathlib
 import shutil
+import typing as t
 
 import pytest
 
 from libvcs.cmd.hg import Hg
+
+if t.TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 if not shutil.which("hg"):
     pytestmark = pytest.mark.skip(reason="hg is not available")
@@ -20,3 +24,17 @@ def test_hg_run_accepts_scalar_string(tmp_path: pathlib.Path) -> None:
     result = repo.run("help")
 
     assert "Mercurial Distributed SCM" in result
+
+
+def test_hg_run_timeout_propagates_to_runner(
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """``Hg.run(timeout=X)`` forwards X to the underlying ``run()``."""
+    repo = Hg(path=tmp_path)
+    mock_run = mocker.patch("libvcs.cmd.hg.run", return_value="")
+
+    repo.run(["help"], timeout=2.5)
+
+    _args, kwargs = mock_run.call_args
+    assert kwargs.get("timeout") == 2.5

--- a/tests/cmd/test_svn.py
+++ b/tests/cmd/test_svn.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import pathlib
 import shutil
+import typing as t
 
 import pytest
 
 from libvcs.cmd.svn import Svn
+
+if t.TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 if not shutil.which("svn"):
     pytestmark = pytest.mark.skip(reason="svn is not available")
@@ -20,3 +24,17 @@ def test_svn_run_accepts_scalar_string(tmp_path: pathlib.Path) -> None:
     result = repo.run("help")
 
     assert "usage: svn <subcommand> [options] [args]" in result
+
+
+def test_svn_run_timeout_propagates_to_runner(
+    tmp_path: pathlib.Path,
+    mocker: MockerFixture,
+) -> None:
+    """``Svn.run(timeout=X)`` forwards X to the underlying ``run()``."""
+    repo = Svn(path=tmp_path)
+    mock_run = mocker.patch("libvcs.cmd.svn.run", return_value="")
+
+    repo.run(["help"], timeout=2.5)
+
+    _args, kwargs = mock_run.call_args
+    assert kwargs.get("timeout") == 2.5

--- a/tests/sync/test_git.py
+++ b/tests/sync/test_git.py
@@ -1666,3 +1666,46 @@ def test_sync_result_multiple_errors() -> None:
     assert len(result.errors) == 2
     assert result.errors[0].step == "fetch"
     assert result.errors[1].step == "checkout"
+
+
+def test_remote_is_fast_for_repos_with_many_refs(
+    git_repo: GitSync,
+    tmp_path: pathlib.Path,
+) -> None:
+    """``GitSync.remote`` stays O(1) even when the repo has thousands of refs.
+
+    The prior implementation called ``git remote show -n origin`` whose output
+    enumerates every remote-tracking ref. For repositories like openai/codex
+    (2,400+ branches) that stream of lines piped through the subprocess
+    progress callback produced the appearance of a hang during vcspull sync.
+
+    This test seeds synthetic refs/remotes/origin/branch-N entries and asserts
+    that ``remote('origin')`` returns promptly. A generous 5-second budget is
+    enough to catch the pathological old path (many seconds on WSL2) without
+    flaking on slow CI.
+    """
+    import time
+
+    # Point origin at a commit we already have so fake refs don't dangle.
+    head_sha = run(["git", "rev-parse", "HEAD"], cwd=git_repo.path).strip()
+
+    # Seed 500 fake remote-tracking refs. ``git update-ref`` is quick but the
+    # cumulative count is what would blow up ``git remote show -n``.
+    for i in range(500):
+        run(
+            [
+                "git",
+                "update-ref",
+                f"refs/remotes/origin/fake-branch-{i:04d}",
+                head_sha,
+            ],
+            cwd=git_repo.path,
+        )
+
+    started = time.monotonic()
+    remote = git_repo.remote("origin")
+    elapsed = time.monotonic() - started
+
+    assert remote is not None
+    assert remote.fetch_url, "fetch URL must be populated"
+    assert elapsed < 5.0, f"remote() too slow: {elapsed:.2f}s with 500 fake refs"

--- a/tests/sync/test_git.py
+++ b/tests/sync/test_git.py
@@ -1709,3 +1709,28 @@ def test_remote_is_fast_for_repos_with_many_refs(
     assert remote is not None
     assert remote.fetch_url, "fetch URL must be populated"
     assert elapsed < 5.0, f"remote() too slow: {elapsed:.2f}s with 500 fake refs"
+
+
+def test_remote_swallows_libvcs_exception(
+    git_repo: GitSync,
+    mocker: MockerFixture,
+) -> None:
+    """``GitSync.remote`` returns ``None`` when ``git remote -v`` fails.
+
+    The pre-rewrite implementation wrapped the underlying subprocess call
+    in ``try / except LibVCSException`` so a corrupt config or a locked
+    ``.git/config`` did not crash a ``vcspull sync``. The new path must
+    preserve that resilience -- callers should still see ``None`` rather
+    than a raised exception.
+    """
+    mocker.patch.object(
+        git_repo.cmd.remotes,
+        "get",
+        side_effect=exc.CommandError(
+            output="fatal: bad config",
+            returncode=128,
+            cmd="git remote --verbose",
+        ),
+    )
+
+    assert git_repo.remote("origin") is None

--- a/tests/sync/test_git.py
+++ b/tests/sync/test_git.py
@@ -6,6 +6,7 @@ import datetime
 import pathlib
 import random
 import shutil
+import subprocess
 import textwrap
 import time
 import typing as t
@@ -1683,23 +1684,25 @@ def test_remote_is_fast_for_repos_with_many_refs(
     This test seeds synthetic refs/remotes/origin/branch-N entries and asserts
     that ``remote('origin')`` returns promptly. A generous 5-second budget is
     enough to catch the pathological old path (many seconds on WSL2) without
-    flaking on slow CI.
+    flaking on slow CI. Refs are batched through ``git update-ref --stdin``
+    (one subprocess) instead of one invocation per ref so the test setup
+    doesn't dominate suite duration.
     """
     # Point origin at a commit we already have so fake refs don't dangle.
     head_sha = run(["git", "rev-parse", "HEAD"], cwd=git_repo.path).strip()
 
-    # Seed 500 fake remote-tracking refs. ``git update-ref`` is quick but the
-    # cumulative count is what would blow up ``git remote show -n``.
-    for i in range(500):
-        run(
-            [
-                "git",
-                "update-ref",
-                f"refs/remotes/origin/fake-branch-{i:04d}",
-                head_sha,
-            ],
-            cwd=git_repo.path,
-        )
+    # Seed 500 fake remote-tracking refs in a single ``git update-ref`` call;
+    # the cumulative count is what would blow up ``git remote show -n``.
+    stdin_input = "".join(
+        f"update refs/remotes/origin/fake-branch-{i:04d} {head_sha}\n"
+        for i in range(500)
+    )
+    subprocess.run(
+        ["git", "-C", str(git_repo.path), "update-ref", "--stdin"],
+        input=stdin_input,
+        text=True,
+        check=True,
+    )
 
     started = time.monotonic()
     remote = git_repo.remote("origin")

--- a/tests/sync/test_git.py
+++ b/tests/sync/test_git.py
@@ -7,6 +7,7 @@ import pathlib
 import random
 import shutil
 import textwrap
+import time
 import typing as t
 from collections.abc import Callable
 
@@ -1684,8 +1685,6 @@ def test_remote_is_fast_for_repos_with_many_refs(
     enough to catch the pathological old path (many seconds on WSL2) without
     flaking on slow CI.
     """
-    import time
-
     # Point origin at a commit we already have so fake refs don't dangle.
     head_sha = run(["git", "rev-parse", "HEAD"], cwd=git_repo.path).strip()
 


### PR DESCRIPTION
## Summary

Two user-visible improvements that let downstream batch-sync tools (e.g. `vcspull sync`) recover from a stuck repository instead of freezing the whole run, with hardening for the failure modes that surface in real-world use.

### 1. `GitSync.remote()` — stop hanging on ref-heavy remotes

`GitSync.remote(name)` used to call `cmd.remotes.show(name=..., no_query_remotes=True, log_in_real_time=True)`. Even with `-n`, `git remote show` walks every remote-tracking ref. On forks of large repos (e.g. `openai/codex` at 2,400+ refs) those lines stream through libvcs's real-time progress callback and appear as a `vcspull sync` hang on WSL2 / slow filesystems.

The URL lookup now reads from `git remote -v` via the remote manager (O(remotes), no ref walk) and falls back to the fetch URL when no explicit `pushurl` is set — matching git's own `push_url_of_remote()` fallback. Subprocess failures (corrupt config, lock contention) still degrade to `None`, preserving the previous resilience contract.

### 2. New `timeout=` keyword on subprocess runners

`libvcs._internal.run.run()` and the public `Git.run()` / `Hg.run()` / `Svn.run()` all accept an opt-in `timeout: float | None = None`. When the deadline fires the child is sent `SIGTERM`, escalated to `SIGKILL` after a short grace period, and `exc.CommandTimeoutError` is raised with any captured output and the deadline duration in its `str()`. `timeout=None` (default) preserves the prior unbounded-wait behaviour byte-for-byte.

The deadline loop registers both stdout and stderr with `selectors` and drains them concurrently, so a child that fills the stdout pipe buffer cannot deadlock waiting for libvcs to read. EOF on either stream unregisters the fd to avoid spinning the CPU; on Windows (where `os.set_blocking` raises) the loop sleeps the poll interval instead of busy-looping. Blocking mode is restored in `finally` so subsequent reads by the caller behave normally.

Operators get structured log breadcrumbs at `WARNING` (deadline exceeded, SIGKILL did not reap) and `DEBUG` (SIGKILL escalated after SIGTERM grace) with the canonical `vcs_cmd` / `vcs_exit_code` extras.

## Hardening covered

Failure modes the deadline loop and remote rewrite now handle:

- Stdout and stderr are drained concurrently so a child filling either pipe buffer cannot deadlock the parent during the SIGTERM grace window.
- Streams are unregistered from the selector on EOF so a child closing one pipe early doesn't spin the loop.
- On Windows (where `os.set_blocking` raises) the loop sleeps the poll interval rather than busy-looping for the whole timeout duration.
- Final pipe drains run before the loop returns so trailing output isn't dropped on the race between `select()` and `poll()`.
- `CommandTimeoutError` renders the deadline duration in its `str()` instead of inheriting the bare `CommandError` template (which would otherwise produce `"Command failed with code None: ..."` on the SIGKILL bail path).
- `GitSync.remote()` retains the previous `try / except LibVCSException` resilience so subprocess failures (corrupt config, locked file) still degrade to `None` rather than leaking as `CommandError`.

## Test plan

- [x] `uv run pytest --reruns 0` — full suite green.
- [x] `uv run ruff check . --fix --show-fixes && uv run ruff format . && uv run mypy` — clean under `strict = true`.
- [x] `just build-docs` — succeeds; new `CommandTimeoutError` doctest runs.
- [x] `uv run pytest tests/_internal/test_run.py -vv` — covers `timeout=None` back-compat, deadline firing within bounded wall clock, partial stdout & stderr capture, child reaping, EOF unregister, and structured log emission.
- [x] `uv run pytest tests/sync/test_git.py::test_remote_is_fast_for_repos_with_many_refs` — seeds 500 synthetic `refs/remotes/origin/*` refs and asserts `remote("origin")` returns under a generous wall-clock budget.
- [x] `uv run pytest tests/cmd/` — `Git.run`, `Hg.run`, `Svn.run` propagate `timeout=` to the underlying runner (mocked).
- [ ] **End-to-end vcspull smoke test against a ref-heavy repo** — recommended before merge; not yet run.

## Notes

- CHANGES updated for the 0.40.x line: a What's new sub-section announcing `timeout=` and a Bug fixes sub-section covering the ref-heavy remote handling.
- `timeout=` is now reachable on every public `Cmd.run` signature; vcspull can adopt it with no further libvcs changes (its existing watchdog around `update_repo()` may want to coordinate with the new in-process deadline).
- The deadline-loop tuning constants are module-private; tests monkeypatch them via a fixture, production callers don't tune them — revisit if real flakes appear.
