### PR TITLE
pytest_plugin(fix[pytest_ignore_collect]): abstain with None

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,12 @@ $ uv add libvcs --prerelease allow
 _Notes on the upcoming release will go here._
 <!-- END PLACEHOLDER - ADD NEW CHANGELOG ENTRIES BELOW THIS LINE -->
 
+### Fixes
+
+- libvcs's bundled pytest plugin no longer overrides pytest's own
+  collection-ignore rules; suites that build their docs before running
+  no longer abort on the generated `_build/` output (#544).
+
 ### Documentation
 
 #### Documentation examples now run as doctests (#540)

--- a/src/libvcs/pytest_plugin.py
+++ b/src/libvcs/pytest_plugin.py
@@ -119,18 +119,30 @@ class RandomStrSequence:
 namer = RandomStrSequence()
 
 
-def pytest_ignore_collect(collection_path: pathlib.Path, config: pytest.Config) -> bool:
-    """Skip tests if VCS binaries are missing."""
+def pytest_ignore_collect(
+    collection_path: pathlib.Path,
+    config: pytest.Config,
+) -> bool | None:
+    """Skip collection of tests that require a missing VCS binary.
+
+    ``pytest_ignore_collect`` is a ``firstresult`` hook: the first
+    implementation to return a non-``None`` value wins and short-circuits the
+    rest. This hook must therefore return ``None`` (abstain) for paths it has
+    no opinion on, so that other implementations -- gp-libs' Sphinx ``_build``
+    skip and pytest's own ``__pycache__``/``norecursedirs``/``collect_ignore``
+    handling -- still run. Returning ``False`` here would suppress all of them.
+    """
     if (not shutil.which("svn") or not shutil.which("svnadmin")) and any(
         needle in str(collection_path) for needle in ["svn", "subversion"]
     ):
         return True
     if not shutil.which("git") and "git" in str(collection_path):
         return True
-    return bool(
-        not shutil.which("hg")
-        and any(needle in str(collection_path) for needle in ["hg", "mercurial"]),
-    )
+    if not shutil.which("hg") and any(
+        needle in str(collection_path) for needle in ["hg", "mercurial"]
+    ):
+        return True
+    return None
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -11,6 +11,7 @@ import typing as t
 import pytest
 
 from libvcs._internal.run import run
+from libvcs.pytest_plugin import pytest_ignore_collect
 
 if t.TYPE_CHECKING:
     import pathlib
@@ -311,3 +312,47 @@ def test_git_repo_fixture_submodule_file_protocol(
         f"git submodule add failed: {result}\n"
         "git_repo fixture needs set_home dependency for child processes"
     )
+
+
+def test_pytest_ignore_collect_abstains_on_non_vcs_path(
+    pytestconfig: pytest.Config,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Non-VCS paths abstain (``None``) rather than voting ``False``.
+
+    ``pytest_ignore_collect`` is a ``firstresult`` hook, so returning ``False``
+    would short-circuit the chain and suppress gp-libs' Sphinx ``_build`` skip
+    and pytest's builtin ignores. A path mentioning no VCS must yield ``None``
+    regardless of which VCS binaries are installed.
+    """
+    build_artifact = tmp_path / "docs" / "_build" / "html" / "history.md"
+
+    assert pytest_ignore_collect(build_artifact, config=pytestconfig) is None
+
+
+def test_pytest_ignore_collect_ignores_missing_vcs(
+    pytestconfig: pytest.Config,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """Paths for a missing VCS binary are ignored (``True``)."""
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda cmd, *args, **kwargs: None if cmd == "git" else f"/usr/bin/{cmd}",
+    )
+    git_test = tmp_path / "tests" / "sync" / "test_git.py"
+
+    assert pytest_ignore_collect(git_test, config=pytestconfig) is True
+
+
+def test_pytest_ignore_collect_abstains_when_binaries_present(
+    pytestconfig: pytest.Config,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    """A VCS path abstains when its binary is present, deferring to others."""
+    monkeypatch.setattr(shutil, "which", lambda cmd, *args, **kwargs: f"/usr/bin/{cmd}")
+    git_test = tmp_path / "tests" / "sync" / "test_git.py"
+
+    assert pytest_ignore_collect(git_test, config=pytestconfig) is None


### PR DESCRIPTION
## Summary

`libvcs.pytest_plugin.pytest_ignore_collect` returned a concrete `False` in
its fall-through instead of `None`. `pytest_ignore_collect` is a
[`firstresult=True`](https://github.com/pytest-dev/pytest/blob/9.1.1/src/_pytest/hookspec.py#L302-L303)
hook, so the first implementation to return a non-`None` value wins and
short-circuits the rest. libvcs's implementation runs first, so its `False`
silently suppressed every other implementation — gp-libs'
[`_build` skip](https://github.com/git-pull/gp-libs/blob/v0.0.18/src/pytest_doctest_docutils.py#L103-L118)
and pytest's own
[`__pycache__`/`norecursedirs`/`collect_ignore` handling](https://github.com/pytest-dev/pytest/blob/9.1.1/src/_pytest/main.py#L437).

The user-visible symptom: after building the docs, the suite aborts during
collection on the generated Sphinx output, whose copied sources have relative
`{include}` targets that don't resolve from `docs/_build/`:

```
ERROR docs/_build/html/history.md - docutils.utils.SystemMessage: Directive "include": file not found: '.../docs/_build/html/../CHANGES'
!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!
```

Full root-cause writeup in #543.

## Fix

Return `None` (abstain) from every non-matching branch so the `firstresult`
chain continues to gp-libs and pytest's builtin. The hook still returns `True`
only to skip tests whose VCS binary is missing. The return annotation widens
to `bool | None` accordingly.

## Testing

- `uv run pytest` — 660 passed, 1 skipped; collection no longer aborts with
  stale `docs/_build/` output on disk.
- Three added regression tests in `tests/test_pytest_plugin.py` cover: abstain
  (`None`) on a non-VCS path, ignore (`True`) when a VCS binary is missing, and
  abstain when the binary is present.
- `uv run ruff check` and `uv run mypy` clean.

Closes #543
